### PR TITLE
Introduce scoped message receivers

### DIFF
--- a/src/Take.Blip.Client.UnitTests/Activation/BootstrapperTests.cs
+++ b/src/Take.Blip.Client.UnitTests/Activation/BootstrapperTests.cs
@@ -233,6 +233,44 @@ namespace Take.Blip.Client.UnitTests.Activation
         }
 
         [Fact]
+        public async Task CreateWithMessageReceiverTypeAndScopedLifetimeShouldNotReturn_Instance()
+        {
+            // Arrange
+            var application = new Application()
+            {
+                Identifier = "testlogin",
+                AccessKey = "12345".ToBase64(),
+                MessageReceivers = new[]
+                {
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).Name,
+                        MediaType = "text/plain",
+                        Lifetime = "scoped"
+                    },
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).Name,
+                        MediaType = "application/json"
+                    },
+                    new MessageApplicationReceiver()
+                    {
+                        Type = typeof(TestMessageReceiver).AssemblyQualifiedName
+                    }
+                },
+                HostName = Server.ListenerUri.Host
+            };
+
+            // Act
+            var actual = await Bootstrapper.StartAsync(CancellationToken, application, typeResolver: TypeResolver);
+
+            // Assert
+            actual.ShouldNotBeNull();
+            TestMessageReceiver.InstanceCount.ShouldBe(2);
+        }
+
+
+        [Fact]
         public async Task CreateWithRegisteringTunnelShouldAddReceiver()
         {
             // Arrange

--- a/src/Take.Blip.Client.UnitTests/Activation/BootstrapperTests.cs
+++ b/src/Take.Blip.Client.UnitTests/Activation/BootstrapperTests.cs
@@ -246,7 +246,7 @@ namespace Take.Blip.Client.UnitTests.Activation
                     {
                         Type = typeof(TestMessageReceiver).Name,
                         MediaType = "text/plain",
-                        Lifetime = "scoped"
+                        Lifetime = ReceiverLifetime.Scoped
                     },
                     new MessageApplicationReceiver()
                     {

--- a/src/Take.Blip.Client/Activation/Application.cs
+++ b/src/Take.Blip.Client/Activation/Application.cs
@@ -98,6 +98,14 @@ namespace Take.Blip.Client.Activation
         public int SendTimeout { get; set; }
 
         /// <summary>
+        /// Gets or sets the default lifetime for MessageReceivers.
+        /// </summary>
+        /// <value>
+        /// The lifetime.
+        /// </value>
+        public ReceiverLifetime DefaultMessageReceiverLifetime { get; set; }
+
+        /// <summary>
         /// Gets or sets the messages receivers.
         /// </summary>
         /// <value>

--- a/src/Take.Blip.Client/Activation/Bootstrapper.cs
+++ b/src/Take.Blip.Client/Activation/Bootstrapper.cs
@@ -351,9 +351,9 @@ namespace Take.Blip.Client.Activation
                     }
                     else
                     {
-                        receiver = await CreateAsync<IMessageReceiver>(
-                            applicationReceiver.Type, serviceContainer, applicationReceiver.Settings, typeResolver)
-                            .ConfigureAwait(false);
+                        var receiverType = typeResolver.Resolve(applicationReceiver.Type);
+                        receiver = await BuildByLifetimeAsync(applicationReceiver.Lifetime, receiverType, applicationReceiver.Settings, serviceContainer)
+                                            .ConfigureAwait(false);
                     }
 
                     if (applicationReceiver.OutState != null)
@@ -499,6 +499,33 @@ namespace Take.Blip.Client.Activation
             return instance;
         }
 
+        private static Task<IMessageReceiver> BuildByLifetimeAsync(string lifetime, Type receiverType, IDictionary<string, object> settings, IServiceContainer serviceContainer)
+        {
+            if ("scoped".Equals(lifetime, StringComparison.InvariantCultureIgnoreCase))
+            {
+                var messageReceiverFactory = GetMessageReceiverFactory(serviceContainer);
+                return Task.FromResult<IMessageReceiver>(new ScopedMessageReceiverWrapper(messageReceiverFactory, receiverType, settings));
+            }
+            else
+            {
+                return CreateAsync<IMessageReceiver>(receiverType, serviceContainer, settings);
+            }
+        }
+
+        private static IMessageReceiverFactory GetMessageReceiverFactory(IServiceContainer container)
+        {
+            IMessageReceiverFactory containerResolved = null;
+            try
+            {
+                containerResolved = container.GetService<IMessageReceiverFactory>();
+            }
+            catch
+            {
+            }
+
+            return containerResolved ?? new MessageReceiverFactory(container);
+        }
+
         private class StoppableWrapper : IStoppable
         {
             private readonly IStoppable[] _stoppables;
@@ -554,5 +581,62 @@ namespace Take.Blip.Client.Activation
                 await _stateManager.SetStateAsync(envelope.From.ToIdentity(), _state, cancellationToken);
             }
         }
+
+        private class ScopedMessageReceiverWrapper : IMessageReceiver
+        {
+            private readonly IMessageReceiverFactory _messageReceiverFactory;
+            private readonly Type _receiverType;
+            private readonly IDictionary<string, object> _settings;
+
+            public ScopedMessageReceiverWrapper(IMessageReceiverFactory messageReceiverFactory, Type receiverType, IDictionary<string, object> settings)
+            {
+                _messageReceiverFactory = messageReceiverFactory;
+                _receiverType = receiverType;
+                _settings = settings;
+            }
+
+            public async Task ReceiveAsync(Message message, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                var receiver = await _messageReceiverFactory.CreateAsync(_receiverType, _settings)
+                        .ConfigureAwait(false);
+
+                try
+                {
+                    await receiver
+                            .ReceiveAsync(message, cancellationToken)
+                            .ConfigureAwait(false);
+                }
+                finally
+                {
+                    await _messageReceiverFactory.ReleaseAsync(receiver);
+                }
+            }
+        }
+
+        private class MessageReceiverFactory : IMessageReceiverFactory
+        {
+            private IServiceProvider _provider;
+
+            public MessageReceiverFactory(IServiceProvider provider)
+            {
+                this._provider = provider;
+            }
+
+            public Task<IMessageReceiver> CreateAsync(Type receiverType, IDictionary<string, object> settings)
+            {
+                return CreateAsync<IMessageReceiver>(receiverType, _provider, settings);
+            }
+
+            public Task ReleaseAsync(IMessageReceiver receiver)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public interface IMessageReceiverFactory
+    {
+        Task<IMessageReceiver> CreateAsync(Type receiverType, IDictionary<string, object> settings);
+        Task ReleaseAsync(IMessageReceiver receiver);
     }
 }

--- a/src/Take.Blip.Client/Activation/Bootstrapper.cs
+++ b/src/Take.Blip.Client/Activation/Bootstrapper.cs
@@ -352,8 +352,11 @@ namespace Take.Blip.Client.Activation
                     else
                     {
                         var receiverType = typeResolver.Resolve(applicationReceiver.Type);
-                        receiver = await BuildByLifetimeAsync(applicationReceiver.Lifetime, receiverType, applicationReceiver.Settings, serviceContainer)
-                                            .ConfigureAwait(false);
+                        receiver = await BuildByLifetimeAsync(
+                            applicationReceiver.Lifetime ?? application.DefaultMessageReceiverLifetime,
+                            receiverType,
+                            applicationReceiver.Settings,
+                            serviceContainer);
                     }
 
                     if (applicationReceiver.OutState != null)
@@ -499,16 +502,17 @@ namespace Take.Blip.Client.Activation
             return instance;
         }
 
-        private static Task<IMessageReceiver> BuildByLifetimeAsync(string lifetime, Type receiverType, IDictionary<string, object> settings, IServiceContainer serviceContainer)
+        private static Task<IMessageReceiver> BuildByLifetimeAsync(ReceiverLifetime lifetime, Type receiverType, IDictionary<string, object> settings, IServiceContainer serviceContainer)
         {
-            if ("scoped".Equals(lifetime, StringComparison.InvariantCultureIgnoreCase))
+            switch (lifetime)
             {
-                var messageReceiverFactory = GetMessageReceiverFactory(serviceContainer);
-                return Task.FromResult<IMessageReceiver>(new ScopedMessageReceiverWrapper(messageReceiverFactory, receiverType, settings));
-            }
-            else
-            {
-                return CreateAsync<IMessageReceiver>(receiverType, serviceContainer, settings);
+                case ReceiverLifetime.Scoped:
+                    var messageReceiverFactory = GetMessageReceiverFactory(serviceContainer);
+                    return Task.FromResult<IMessageReceiver>(new ScopedMessageReceiverWrapper(messageReceiverFactory, receiverType, settings));
+
+                case ReceiverLifetime.Singleton:
+                default:
+                    return CreateAsync<IMessageReceiver>(receiverType, serviceContainer, settings);
             }
         }
 
@@ -608,7 +612,9 @@ namespace Take.Blip.Client.Activation
                 }
                 finally
                 {
-                    await _messageReceiverFactory.ReleaseAsync(receiver);
+                    await _messageReceiverFactory
+                            .ReleaseAsync(receiver)
+                            .ConfigureAwait(false);
                 }
             }
         }
@@ -619,7 +625,7 @@ namespace Take.Blip.Client.Activation
 
             public MessageReceiverFactory(IServiceProvider provider)
             {
-                this._provider = provider;
+                _provider = provider;
             }
 
             public Task<IMessageReceiver> CreateAsync(Type receiverType, IDictionary<string, object> settings)

--- a/src/Take.Blip.Client/Activation/MessageApplicationReceiver.cs
+++ b/src/Take.Blip.Client/Activation/MessageApplicationReceiver.cs
@@ -25,9 +25,9 @@ namespace Take.Blip.Client.Activation
         /// <summary>
         /// Gets or sets the lifetime of the receiver instance.
         /// Options:
-        /// - singleton (default)
-        /// - scoped (an instance per message request)
+        /// - Singleton (default)
+        /// - Scoped (an instance per message request)
         /// </summary>
-        public string Lifetime { get; set; }
+        public ReceiverLifetime? Lifetime { get; set; }
     }
 }

--- a/src/Take.Blip.Client/Activation/MessageApplicationReceiver.cs
+++ b/src/Take.Blip.Client/Activation/MessageApplicationReceiver.cs
@@ -21,5 +21,13 @@ namespace Take.Blip.Client.Activation
         /// The text regex.
         /// </value>
         public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lifetime of the receiver instance.
+        /// Options:
+        /// - singleton (default)
+        /// - scoped (an instance per message request)
+        /// </summary>
+        public string Lifetime { get; set; }
     }
 }

--- a/src/Take.Blip.Client/Activation/ReceiverLifetime.cs
+++ b/src/Take.Blip.Client/Activation/ReceiverLifetime.cs
@@ -1,0 +1,8 @@
+﻿namespace Take.Blip.Client.Activation
+{
+    public enum ReceiverLifetime
+    {
+        Singleton,
+        Scoped
+    }
+}


### PR DESCRIPTION
The current implementation creates all MessageReceivers instances when starting.

I think could be very useful to allow clients to override this behavior.
For instance, in order to produce instances scoped by message for instance: imagine a context provider which can offer the message, the contact for this message and other properties related to current user.

To allow this scenario I have added IMessageReceiverFactory, which is used to get the receiver before processing each request. If no implementation could be found by the IServiceProvider, a default implementing the current logic will be used.

Some tests are intentionally failing to demonstrate the impacts of this change. If this request manages to be accepted they should probably be deleted.