### PR TITLE
Add config to optionally include user identity on every ProcessHttp action request

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
@@ -23,6 +23,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
         public ProcessHttpActionTests()
         {
             HttpClient = Substitute.For<IHttpClient>();
+            Context.Flow.Returns(new Builder.Models.Flow { Configuration = new Dictionary<string, string>() });
         }
 
         public IHttpClient HttpClient { get; set; }
@@ -119,8 +120,8 @@ namespace Take.Blip.Builder.UnitTests.Actions
         {
             //Arrange
             const string userIdentity = "user@domain.local";
-            const string userToRequestHeaderVariableName = "config.processHttp.addUserToRequestHeader";        
-            Context.GetVariableAsync(userToRequestHeaderVariableName, Arg.Any<CancellationToken>()).Returns("true");
+            const string userToRequestHeaderVariableName = "processHttp.addUserToRequestHeader";        
+            Context.Flow.Configuration.Add(userToRequestHeaderVariableName, "true");
             Context.User.Returns(Identity.Parse(userIdentity));
 
             var settings = new ProcessHttpSettings
@@ -155,10 +156,8 @@ namespace Take.Blip.Builder.UnitTests.Actions
             await target.ExecuteAsync(Context, JObject.FromObject(settings), CancellationToken);
 
             //Assert
-            requestMessage.Headers.Contains("X-BLIP-USER").ShouldBeTrue();
-            requestMessage.Headers.GetValues("X-BLIP-USER").First().ShouldBe(userIdentity);
-
-            await Context.Received(1).GetVariableAsync(userToRequestHeaderVariableName, CancellationToken);
+            requestMessage.Headers.Contains("X-Blip-User").ShouldBeTrue();
+            requestMessage.Headers.GetValues("X-Blip-User").First().ShouldBe(userIdentity);
 
             await HttpClient.Received(1).SendAsync(
                 Arg.Is<HttpRequestMessage>(

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -83,7 +83,7 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
             var userHeaderValue = await context.GetVariableAsync("config.processHttp.addUserToRequestHeader", cancellationToken);
             if (bool.TryParse(userHeaderValue, out bool sendUserHeader) && sendUserHeader)
             {
-                httpRequestMessage.Headers.Add("X-BLIP-USER", context.User);
+                httpRequestMessage.Headers.Add("X-Blip-User", context.User);
             }
         }
 

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -78,9 +78,16 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
             }
         }
 
+        /// <summary>
+        /// Add 'X-Blip-User' header to request, with current user identity as its value, if there is 
+        /// a configuration variable 'processHttp.addUserToRequestHeader' set to true
+        /// </summary>
+        /// <param name="httpRequestMessage"></param>
+        /// <param name="context"></param>
         private void AddUserToHeaders(HttpRequestMessage httpRequestMessage, IContext context)
         {
-            if (context.Flow.Configuration.TryGetValue("processHttp.addUserToRequestHeader", out string userHeaderValue) && 
+            if (context.Flow.Configuration != null &&
+                context.Flow.Configuration.TryGetValue("processHttp.addUserToRequestHeader", out string userHeaderValue) && 
                 bool.TryParse(userHeaderValue, out bool sendUserHeader) && 
                 sendUserHeader)
             {

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -46,7 +46,7 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
                             contentType ?? "application/json");
                     }
 
-                    await AddUserToHeaderAsync(httpRequestMessage, context, cancellationToken);
+                    AddUserToHeaders(httpRequestMessage, context);
 
                     using (var httpResponseMessage =
                         await _httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
@@ -78,10 +78,11 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
             }
         }
 
-        private async Task AddUserToHeaderAsync(HttpRequestMessage httpRequestMessage, IContext context, CancellationToken cancellationToken)
+        private void AddUserToHeaders(HttpRequestMessage httpRequestMessage, IContext context)
         {
-            var userHeaderValue = await context.GetVariableAsync("config.processHttp.addUserToRequestHeader", cancellationToken);
-            if (bool.TryParse(userHeaderValue, out bool sendUserHeader) && sendUserHeader)
+            if (context.Flow.Configuration.TryGetValue("processHttp.addUserToRequestHeader", out string userHeaderValue) && 
+                bool.TryParse(userHeaderValue, out bool sendUserHeader) && 
+                sendUserHeader)
             {
                 httpRequestMessage.Headers.Add("X-Blip-User", context.User);
             }

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -46,6 +46,8 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
                             contentType ?? "application/json");
                     }
 
+                    await AddUserToHeaderAsync(httpRequestMessage, context, cancellationToken);
+
                     using (var httpResponseMessage =
                         await _httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
                     {
@@ -73,6 +75,15 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
                 !string.IsNullOrWhiteSpace(responseBody))
             {
                 await context.SetVariableAsync(settings.ResponseBodyVariable, responseBody, cancellationToken);
+            }
+        }
+
+        private async Task AddUserToHeaderAsync(HttpRequestMessage httpRequestMessage, IContext context, CancellationToken cancellationToken)
+        {
+            var userHeaderValue = await context.GetVariableAsync("config.processHttp.addUserToRequestHeader", cancellationToken);
+            if (bool.TryParse(userHeaderValue, out bool sendUserHeader) && sendUserHeader)
+            {
+                httpRequestMessage.Headers.Add("X-BLIP-USER", context.User);
             }
         }
 


### PR DESCRIPTION
It is very interesting to identify from who requests are coming.
Adding an optional configuration variable ('config.processHttp.addUserToRequestHeader')  to do this on every request will ease developers work.