### PR TITLE
Add Exists and NotExists to OutputConditions in Builder

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Models/ConditionComparisonTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Models/ConditionComparisonTests.cs
@@ -17,7 +17,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value 1";
-            var target = ConditionComparison.Equals.ToDelegate();
+            var target = ConditionComparison.Equals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -29,7 +29,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "ValUe 1";
             var value2 = "value 1";
-            var target = ConditionComparison.Equals.ToDelegate();
+            var target = ConditionComparison.Equals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -41,7 +41,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 😱🤢➡";
             var value2 = "Value 😱🤢➡";
-            var target = ConditionComparison.Equals.ToDelegate();
+            var target = ConditionComparison.Equals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -53,7 +53,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Valuê 1";
             var value2 = "Válue 1";
-            var target = ConditionComparison.Equals.ToDelegate();
+            var target = ConditionComparison.Equals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -64,7 +64,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value X";
-            var target = ConditionComparison.Equals.ToDelegate();
+            var target = ConditionComparison.Equals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -76,7 +76,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value 1";
-            var target = ConditionComparison.NotEquals.ToDelegate();
+            var target = ConditionComparison.NotEquals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -88,7 +88,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "ValUe 1";
             var value2 = "value 1";
-            var target = ConditionComparison.NotEquals.ToDelegate();
+            var target = ConditionComparison.NotEquals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -100,7 +100,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Valuê 1";
             var value2 = "Válue 1";
-            var target = ConditionComparison.NotEquals.ToDelegate();
+            var target = ConditionComparison.NotEquals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -111,7 +111,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value X";
-            var target = ConditionComparison.NotEquals.ToDelegate();
+            var target = ConditionComparison.NotEquals.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -123,7 +123,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value 1";
-            var target = ConditionComparison.StartsWith.ToDelegate();
+            var target = ConditionComparison.StartsWith.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -135,7 +135,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "ValUe 1";
             var value2 = "value 1";
-            var target = ConditionComparison.StartsWith.ToDelegate();
+            var target = ConditionComparison.StartsWith.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -147,7 +147,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Valu";
-            var target = ConditionComparison.StartsWith.ToDelegate();
+            var target = ConditionComparison.StartsWith.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -159,7 +159,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Balue";
-            var target = ConditionComparison.StartsWith.ToDelegate();
+            var target = ConditionComparison.StartsWith.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -172,7 +172,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "12345";
             var value2 = "1234";
-            var target = ConditionComparison.GreaterThan.ToDelegate();
+            var target = ConditionComparison.GreaterThan.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -184,7 +184,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "12345";
             var value2 = "12345";
-            var target = ConditionComparison.GreaterThan.ToDelegate();
+            var target = ConditionComparison.GreaterThan.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -196,7 +196,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "1234";
             var value2 = "12345";
-            var target = ConditionComparison.GreaterThan.ToDelegate();
+            var target = ConditionComparison.GreaterThan.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -208,7 +208,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "not a number";
             var value2 = "also not a number";
-            var target = ConditionComparison.GreaterThan.ToDelegate();
+            var target = ConditionComparison.GreaterThan.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();
@@ -220,7 +220,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Value 1";
-            var target = ConditionComparison.ApproximateTo.ToDelegate();
+            var target = ConditionComparison.ApproximateTo.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -232,7 +232,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "ValUe 1";
             var value2 = "value 1";
-            var target = ConditionComparison.ApproximateTo.ToDelegate();
+            var target = ConditionComparison.ApproximateTo.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -244,7 +244,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Valuê 1";
             var value2 = "Válue 1";
-            var target = ConditionComparison.ApproximateTo.ToDelegate();
+            var target = ConditionComparison.ApproximateTo.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -256,7 +256,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Vilue X";
-            var target = ConditionComparison.ApproximateTo.ToDelegate();
+            var target = ConditionComparison.ApproximateTo.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeTrue();
@@ -268,7 +268,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             // Arrange
             var value1 = "Value 1";
             var value2 = "Hello world";
-            var target = ConditionComparison.ApproximateTo.ToDelegate();
+            var target = ConditionComparison.ApproximateTo.ToBinaryDelegate();
 
             // Act
             target(value1, value2).ShouldBeFalse();

--- a/src/Take.Blip.Builder.UnitTests/Models/ConditionComparisonTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Models/ConditionComparisonTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Shouldly;
+﻿using Shouldly;
 using Take.Blip.Builder.Models;
 using Xunit;
 
@@ -12,7 +7,7 @@ namespace Take.Blip.Builder.UnitTests.Models
     public class ConditionComparisonTests
     {
         [Fact]
-        public void EqualsComparisonWithEqualsValuesShouldSuccceed()
+        public void EqualsComparisonWithEqualsValuesShouldSucceed()
         {
             // Arrange
             var value1 = "Value 1";
@@ -24,7 +19,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void EqualsComparisonWithEqualsValuesWithDifferentCasingShouldSuccceed()
+        public void EqualsComparisonWithEqualsValuesWithDifferentCasingShouldSucceed()
         {
             // Arrange
             var value1 = "ValUe 1";
@@ -36,7 +31,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void EqualsComparisonWithEqualsValuesWithEmojiShouldSuccceed()
+        public void EqualsComparisonWithEqualsValuesWithEmojiShouldSucceed()
         {
             // Arrange
             var value1 = "Value 😱🤢➡";
@@ -48,7 +43,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
     
         [Fact]
-        public void EqualsComparisonWithEqualsValuesWithAccentShouldSuccceed()
+        public void EqualsComparisonWithEqualsValuesWithAccentShouldSucceed()
         {
             // Arrange
             var value1 = "Valuê 1";
@@ -118,7 +113,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void StartsWithComparisonWithEqualsValuesShouldSuccceed()
+        public void StartsWithComparisonWithEqualsValuesShouldSucceed()
         {
             // Arrange
             var value1 = "Value 1";
@@ -130,7 +125,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void StartsWithComparisonWithEqualsValuesWithDifferentCasingShouldSuccceed()
+        public void StartsWithComparisonWithEqualsValuesWithDifferentCasingShouldSucceed()
         {
             // Arrange
             var value1 = "ValUe 1";
@@ -142,7 +137,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void StartsWithComparisonWithPartialValuesShouldSuccceed()
+        public void StartsWithComparisonWithPartialValuesShouldSucceed()
         {
             // Arrange
             var value1 = "Value 1";
@@ -167,7 +162,7 @@ namespace Take.Blip.Builder.UnitTests.Models
 
 
         [Fact]
-        public void GreaterThanWithComparisonWithBiggerValuesShouldSuccceed()
+        public void GreaterThanWithComparisonWithBiggerValuesShouldSucceed()
         {
             // Arrange
             var value1 = "12345";
@@ -215,7 +210,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void ApproximateToComparisonWithApproximateToValuesShouldSuccceed()
+        public void ApproximateToComparisonWithApproximateToValuesShouldSucceed()
         {
             // Arrange
             var value1 = "Value 1";
@@ -227,7 +222,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void ApproximateToComparisonWithApproximateToValuesWithDifferentCasingShouldSuccceed()
+        public void ApproximateToComparisonWithApproximateToValuesWithDifferentCasingShouldSucceed()
         {
             // Arrange
             var value1 = "ValUe 1";
@@ -239,7 +234,7 @@ namespace Take.Blip.Builder.UnitTests.Models
         }
 
         [Fact]
-        public void ApproximateToComparisonWithApproximateToValuesWithAccentShouldSuccceed()
+        public void ApproximateToComparisonWithApproximateToValuesWithAccentShouldSucceed()
         {
             // Arrange
             var value1 = "Valuê 1";
@@ -272,6 +267,72 @@ namespace Take.Blip.Builder.UnitTests.Models
 
             // Act
             target(value1, value2).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExistsComparisonWithExistingValueShouldSucceed()
+        {
+            // Arrange
+            var value = "Value";
+            var target = ConditionComparison.Exists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ExistsComparisonWithEmptyStringShouldFail()
+        {
+            // Arrange
+            var value = "";
+            var target = ConditionComparison.Exists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExistsComparisonNonExistingValueShouldFail()
+        {
+            // Arrange
+            string value = null;
+            var target = ConditionComparison.Exists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NotExistsComparisonWithExistingValueShouldFail()
+        {
+            // Arrange
+            var value = "Value";
+            var target = ConditionComparison.NotExists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NotExistsComparisonWithEmptyStringShouldSucceed()
+        {
+            // Arrange
+            var value = "";
+            var target = ConditionComparison.NotExists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void NotExistsComparisonNonExistingValueShouldSucceed()
+        {
+            // Arrange
+            string value = null;
+            var target = ConditionComparison.NotExists.ToUnaryDelegate();
+
+            // Act
+            target(value).ShouldBeTrue();
         }
     }
 }

--- a/src/Take.Blip.Builder.UnitTests/Models/ConditionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Models/ConditionTests.cs
@@ -41,7 +41,7 @@ namespace Take.Blip.Builder.UnitTests.Models
             }
             catch (ValidationException ex)
             {
-                ex.Message.ShouldBe("The condition values are required");
+                ex.Message.ShouldBe("The condition values should be provided if comparison is not Exists or NotExists");
             }
         }
 

--- a/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
@@ -3,9 +3,6 @@ using Lime.Protocol;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Take.Blip.Builder.Models;
@@ -211,172 +208,9 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
         }
 
         [Fact]
-        public async Task FlowWithTextContextOutputConditionsShouldChangeStateAndSendMessage()
+        public async Task FlowWithMatchTextContextOutputConditionsShouldChangeStateAndSendMessage()
         {
-            // Tests for OutputConditions (Equals, Contains, Starts, Ends)
-            // Arrange
-            var validInput = "Ping!";
-            var messageType = "text/plain";
-            var messageContent = "Pong!";
-
-            var equalsInput = new PlainText() { Text = validInput };
-            var equalsWithAccentInput = new PlainText() { Text = "Píng!" };
-            var containsInput = new PlainText() { Text = "ing" };
-            var startsInput = new PlainText() { Text = "Pin" };
-            var endsInput = new PlainText() { Text = "g!" };
-            var approximateInput = new PlainText() { Text = "Pamg!" };
-
-            var variableName = "MyVariable";
-            var flow = new Flow()
-            {
-                Id = Guid.NewGuid().ToString(),
-                States = new[]
-                {
-                    new State
-                    {
-                        Id = "root",
-                        Root = true,
-                        Input = new Input
-                        {
-                            Variable = variableName
-                        },
-                        Outputs = new Output[]
-                        {
-                            new Output
-                            {
-                                Order = 2,
-                                Conditions = new Condition[]
-                                {
-                                    new Condition
-                                    {
-                                        Source = ValueSource.Context,
-                                        Comparison = ConditionComparison.Equals,
-                                        Variable = variableName,
-                                        Values = new[] { validInput }
-                                    }
-                                },
-                                StateId = "state2"
-                            },
-                            new Output
-                            {
-                                Order = 1,
-                                Conditions = new Condition[]
-                                {
-                                    new Condition
-                                    {
-                                        Source = ValueSource.Context,
-                                        Comparison = ConditionComparison.Contains,
-                                        Variable = variableName,
-                                        Values = new[] { validInput }
-                                    }
-                                },
-                                StateId = "state2"
-                            },
-                            new Output
-                            {
-                                Order = 3,
-                                Conditions = new Condition[]
-                                {
-                                    new Condition
-                                    {
-                                        Source = ValueSource.Context,
-                                        Comparison = ConditionComparison.StartsWith,
-                                        Variable = variableName,
-                                        Values = new[] { validInput }
-                                    }
-                                },
-                                StateId = "state2"
-                            },
-                            new Output
-                            {
-                                Order = 4,
-                                Conditions = new Condition[]
-                                {
-                                    new Condition
-                                    {
-                                        Source = ValueSource.Context,
-                                        Comparison = ConditionComparison.EndsWith,
-                                        Variable = variableName,
-                                        Values = new[] { validInput }
-                                    }
-                                },
-                                StateId = "state2"
-                            },
-                            new Output
-                            {
-                                Order = 5,
-                                Conditions = new Condition[]
-                                {
-                                    new Condition
-                                    {
-                                        Source = ValueSource.Context,
-                                        Comparison = ConditionComparison.ApproximateTo,
-                                        Variable = variableName,
-                                        Values = new[] { validInput }
-                                    }
-                                },
-                                StateId = "state2"
-                            }
-                        }
-                    },
-                    new State
-                    {
-                        Id = "state2",
-                        InputActions = new Action[]
-                        {
-                            new Action
-                            {
-                                Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-            var target = GetTarget();
-
-            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(validInput);
-
-            // Act
-            await target.ProcessInputAsync(equalsInput, User, flow, CancellationToken);
-            await target.ProcessInputAsync(equalsWithAccentInput, User, flow, CancellationToken);
-            await target.ProcessInputAsync(containsInput, User, flow, CancellationToken);
-            await target.ProcessInputAsync(startsInput, User, flow, CancellationToken);
-            await target.ProcessInputAsync(endsInput, User, flow, CancellationToken);
-            await target.ProcessInputAsync(approximateInput, User, flow, CancellationToken);
-
-
-            // Assert
-            ContextProvider.Received(6).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
-            await StateManager.Received(6).SetStateIdAsync(Arg.Any<string>(), Arg.Any<Identity>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-
-            await Context.Received(1).SetVariableAsync(variableName, equalsInput.Text, Arg.Any<CancellationToken>());
-            await Context.Received(1).SetVariableAsync(variableName, equalsWithAccentInput.Text, Arg.Any<CancellationToken>());
-            await Context.Received(1).SetVariableAsync(variableName, containsInput.Text, Arg.Any<CancellationToken>());
-            await Context.Received(1).SetVariableAsync(variableName, startsInput.Text, Arg.Any<CancellationToken>());
-            await Context.Received(1).SetVariableAsync(variableName, endsInput.Text, Arg.Any<CancellationToken>());
-            await Context.Received(1).SetVariableAsync(variableName, approximateInput.Text, Arg.Any<CancellationToken>());
-
-            await Sender
-                .Received(6)
-                .SendMessageAsync(
-                    Arg.Is<Message>(m =>
-                        m.Id != null
-                        && m.To.ToIdentity().Equals(User)
-                        && m.Type.ToString().Equals(messageType)
-                        && m.Content.ToString() == messageContent),
-                    Arg.Any<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task FlowWithMachTextContextOutputConditionsShouldChangeStateAndSendMessage()
-        {
-            // Tests for Maches OutputConditions
+            // Tests for Matches OutputConditions
             // Arrange
             var validInput = "Ping!";
             var messageType = "text/plain";
@@ -459,5 +293,603 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                     Arg.Any<CancellationToken>());
         }
 
+        private Flow ConditionComparisonFlowPrep(ConditionComparison condition, string variableName, string sentMessageType, string sentMessageContent)
+        {
+            return new Flow()
+            {
+                Id = Guid.NewGuid().ToString(),
+                States = new[]
+                {
+                    new State
+                    {
+                        Id = "root",
+                        Root = true,
+                        Input = new Input
+                        {
+                            Variable = variableName
+                        },
+                        Outputs = new Output[]
+                        {
+                            new Output
+                            {
+                                Order = 1,
+                                Conditions = new Condition[]
+                                {
+                                    new Condition
+                                    {
+                                        Source = ValueSource.Context,
+                                        Comparison = condition,
+                                        Variable = variableName,
+                                    }
+                                },
+                                StateId = "success"
+                            }
+                        }
+                    },
+                    new State
+                    {
+                        Id = "success",
+                        InputActions = new Action[]
+                        {
+                            new Action
+                            {
+                                Type = "SendMessage",
+                                Settings = new JObject()
+                                {
+                                    {"type", sentMessageType},
+                                    {"content", sentMessageContent}
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        private Flow ConditionComparisonFlowPrep(ConditionComparison condition, string variableName, string validInputValue, string sentMessageType, string sentMessageContent)
+        {
+            return new Flow()
+            {
+                Id = Guid.NewGuid().ToString(),
+                States = new[]
+                {
+                    new State
+                    {
+                        Id = "root",
+                        Root = true,
+                        Input = new Input
+                        {
+                            Variable = variableName
+                        },
+                        Outputs = new Output[]
+                        {
+                            new Output
+                            {
+                                Order = 1,
+                                Conditions = new Condition[]
+                                {
+                                    new Condition
+                                    {
+                                        Source = ValueSource.Context,
+                                        Comparison = condition,
+                                        Variable = variableName,
+                                        Values = new[] { validInputValue }
+                                    }
+                                },
+                                StateId = "success"
+                            }
+                        }
+                    },
+                    new State
+                    {
+                        Id = "success",
+                        InputActions = new Action[]
+                        {
+                            new Action
+                            {
+                                Type = "SendMessage",
+                                Settings = new JObject()
+                                {
+                                    {"type", sentMessageType},
+                                    {"content", sentMessageContent}
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionEqualsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Equals
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var equalsInput = new PlainText() { Text = validInputValue };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(equalsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(equalsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, equalsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionEqualsShouldNotChangeState()
+        {
+            // Tests for OutputConditions => Equals
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var equalsInput = new PlainText() { Text = "Not Ping!" };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(equalsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(equalsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, equalsInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionContainsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Contains
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "ing";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var containsInput = new PlainText() { Text = "Ping!" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(containsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(containsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(Arg.Any<string>(), Arg.Any<Identity>(), "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, containsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionContainsShouldNotChangeState()
+        {
+            // Tests for OutputConditions => Contains
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var containsInput = new PlainText() { Text = "ing" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(containsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(containsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, containsInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionStartsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Starts
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Pin";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var startsInput = new PlainText() { Text = "Ping!" };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(startsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(startsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, startsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionStartsShouldNotChangeState()
+        {
+            // Tests for OutputConditions => Starts
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var startsInput = new PlainText() { Text = "Pin" };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(startsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(startsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, startsInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionEndsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Ends
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "g!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var endsInput = new PlainText() { Text = "Ping!" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(endsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(endsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, endsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionEndsShouldNotChangeState()
+        {
+            // Tests for OutputConditions => Ends
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var endsInput = new PlainText() { Text = "g!" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(endsInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(endsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, endsInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionApproximateToShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => ApproximateTo
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var approximateInput = new PlainText() { Text = "Pamg!" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(approximateInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(approximateInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, approximateInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionApproximateToShouldNotChangeState()
+        {
+            // Tests for OutputConditions => ApproximateTo
+            // Arrange
+            var variableName = "MyVariable";
+
+            var validInputValue = "Ping!";
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var approximateInput = new PlainText() { Text = "Pamh!" };
+
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
+
+            var target = GetTarget();
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(approximateInput.Text);
+
+            // Act
+            await target.ProcessInputAsync(approximateInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, approximateInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionExistsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Exists
+            // Arrange
+            var variableName = "MyVariable";
+
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var existsInput = new PlainText() { Text = "Ping!" };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
+
+            var target = GetTarget();
+
+            // Act
+            await target.ProcessInputAsync(existsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionExistsShouldNotChangeState()
+        {
+            // Tests for OutputConditions => Exists
+            // Arrange
+            var variableName = "MyVariable";
+
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var existsInput = new PlainText() { };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
+
+            var target = GetTarget();
+
+            // Act
+            await target.ProcessInputAsync(existsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionNotExistsShouldChangeStateAndSendMessage()
+        {
+            // Tests for OutputConditions => Exists
+            // Arrange
+            var variableName = "MyVariable";
+
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var existsInput = new PlainText() { };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
+
+            var target = GetTarget();
+
+            // Act
+            await target.ProcessInputAsync(existsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
+
+            await Sender
+                .Received(1)
+                .SendMessageAsync(
+                    Arg.Is<Message>(m =>
+                        m.Id != null
+                        && m.To.ToIdentity().Equals(User)
+                        && m.Type.ToString().Equals(sentMessageType)
+                        && m.Content.ToString() == sentMessageContent),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task FlowWithOutputConditionNotExistsShouldNotChange()
+        {
+            // Tests for OutputConditions => Exists
+            // Arrange
+            var variableName = "MyVariable";
+
+            var sentMessageType = "text/plain";
+            var sentMessageContent = "Pong!";
+
+            var existsInput = new PlainText() { Text = "Ping!" };
+
+            var flow = ConditionComparisonFlowPrep(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
+
+            Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
+
+            var target = GetTarget();
+
+            // Act
+            await target.ProcessInputAsync(existsInput, User, flow, CancellationToken);
+
+            // Assert
+            ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
+
+            await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
+        }
     }
 }

--- a/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
@@ -293,7 +293,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                     Arg.Any<CancellationToken>());
         }
 
-        private Flow ConditionComparisonFlowPrep(ConditionComparison condition, string variableName, string sentMessageType, string sentMessageContent)
+        private Flow CreateVariableComparisonFlow(ConditionComparison condition, string variableName, string sentMessageType, string sentMessageContent)
         {
             return new Flow()
             {
@@ -346,7 +346,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             };
         }
 
-        private Flow ConditionComparisonFlowPrep(ConditionComparison condition, string variableName, string validInputValue, string sentMessageType, string sentMessageContent)
+        private Flow CreateVariableComparisonFlow(ConditionComparison condition, string variableName, string validInputValue, string sentMessageType, string sentMessageContent)
         {
             return new Flow()
             {
@@ -406,17 +406,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Equals
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var equalsInput = new PlainText() { Text = validInputValue };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(equalsInput.Text);
 
             // Act
@@ -424,11 +420,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, equalsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -446,17 +439,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Equals
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var equalsInput = new PlainText() { Text = "Not Ping!" };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Equals, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(equalsInput.Text);
 
             // Act
@@ -464,9 +453,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, equalsInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -476,18 +463,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Contains
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "ing";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var containsInput = new PlainText() { Text = "Ping!" };
 
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(containsInput.Text);
 
             // Act
@@ -495,11 +477,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(Arg.Any<string>(), Arg.Any<Identity>(), "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, containsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -517,18 +496,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Contains
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var containsInput = new PlainText() { Text = "ing" };
 
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Contains, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(containsInput.Text);
 
             // Act
@@ -536,9 +510,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, containsInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -548,17 +520,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Starts
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Pin";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var startsInput = new PlainText() { Text = "Ping!" };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(startsInput.Text);
 
             // Act
@@ -566,11 +534,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, startsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -588,17 +553,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Starts
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var startsInput = new PlainText() { Text = "Pin" };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.StartsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(startsInput.Text);
 
             // Act
@@ -606,9 +567,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, startsInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -618,18 +577,14 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Ends
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "g!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var endsInput = new PlainText() { Text = "Ping!" };
 
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(endsInput.Text);
 
             // Act
@@ -637,11 +592,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, endsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -659,18 +611,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Ends
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var endsInput = new PlainText() { Text = "g!" };
 
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.EndsWith, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(endsInput.Text);
 
             // Act
@@ -678,9 +625,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, endsInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -690,18 +635,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => ApproximateTo
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var approximateInput = new PlainText() { Text = "Pamg!" };
 
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(approximateInput.Text);
 
             // Act
@@ -709,11 +649,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, approximateInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -731,18 +668,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => ApproximateTo
             // Arrange
             var variableName = "MyVariable";
-
             var validInputValue = "Ping!";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var approximateInput = new PlainText() { Text = "Pamh!" };
 
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.ApproximateTo, variableName, validInputValue, sentMessageType, sentMessageContent);
             var target = GetTarget();
-
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(approximateInput.Text);
 
             // Act
@@ -750,9 +682,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, approximateInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -762,16 +692,12 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Exists
             // Arrange
             var variableName = "MyVariable";
-
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var existsInput = new PlainText() { Text = "Ping!" };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
-
             var target = GetTarget();
 
             // Act
@@ -779,11 +705,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -801,16 +724,12 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Exists
             // Arrange
             var variableName = "MyVariable";
-
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var existsInput = new PlainText() { };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
-
             var target = GetTarget();
 
             // Act
@@ -818,9 +737,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
         }
 
@@ -830,16 +747,12 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Exists
             // Arrange
             var variableName = "MyVariable";
-
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
+            var existsInput = new PlainText();
 
-            var existsInput = new PlainText() { };
-
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
-
             var target = GetTarget();
 
             // Act
@@ -847,11 +760,8 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.Received(1).SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
-
             await Sender
                 .Received(1)
                 .SendMessageAsync(
@@ -869,16 +779,12 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             // Tests for OutputConditions => Exists
             // Arrange
             var variableName = "MyVariable";
-
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-
             var existsInput = new PlainText() { Text = "Ping!" };
 
-            var flow = ConditionComparisonFlowPrep(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
-
+            var flow = CreateVariableComparisonFlow(ConditionComparison.NotExists, variableName, sentMessageType, sentMessageContent);
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);
-
             var target = GetTarget();
 
             // Act
@@ -886,9 +792,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
 
             // Assert
             ContextProvider.Received(1).CreateContext(User, Arg.Any<LazyInput>(), flow);
-
             await StateManager.DidNotReceive().SetStateIdAsync(flow.Id, User, "success", Arg.Any<CancellationToken>());
-
             await Context.Received(1).SetVariableAsync(variableName, existsInput.Text, Arg.Any<CancellationToken>());
         }
     }

--- a/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
@@ -726,7 +726,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var variableName = "MyVariable";
             var sentMessageType = "text/plain";
             var sentMessageContent = "Pong!";
-            var existsInput = new PlainText() { };
+            var existsInput = new PlainText();
 
             var flow = CreateVariableComparisonFlow(ConditionComparison.Exists, variableName, sentMessageType, sentMessageContent);
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(existsInput.Text);

--- a/src/Take.Blip.Builder.UnitTests/Take.Blip.Builder.UnitTests.csproj
+++ b/src/Take.Blip.Builder.UnitTests/Take.Blip.Builder.UnitTests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.3" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -273,17 +273,7 @@ namespace Take.Blip.Builder
                 case ComparisonType.Unary:
                     var unaryComparisonFunc = condition.Comparison.ToUnaryDelegate();
 
-                    switch (condition.Operator)
-                    {
-                        case ConditionOperator.Or:
-                            return condition.Values.Any(unaryComparisonFunc);
-
-                        case ConditionOperator.And:
-                            return condition.Values.All(unaryComparisonFunc);
-
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
+                    return unaryComparisonFunc(comparisonValue);
 
                 case ComparisonType.Binary:
                     var binaryComparisonFunc = condition.Comparison.ToBinaryDelegate();

--- a/src/Take.Blip.Builder/Models/Condition.cs
+++ b/src/Take.Blip.Builder/Models/Condition.cs
@@ -56,18 +56,18 @@ namespace Take.Blip.Builder.Models
                 throw new ValidationException("The condition values should not be provided if comparison is Exists or NotExists");
             }
 
-            if ( (Comparison == ConditionComparison.Equals 
-               || Comparison == ConditionComparison.NotEquals
-               || Comparison == ConditionComparison.Contains
-               || Comparison == ConditionComparison.StartsWith
-               || Comparison == ConditionComparison.EndsWith
-               || Comparison == ConditionComparison.GreaterThan
-               || Comparison == ConditionComparison.LessThan
-               || Comparison == ConditionComparison.GreaterThanOrEquals
-               || Comparison == ConditionComparison.LessThanOrEquals
-               || Comparison == ConditionComparison.Matches
-               || Comparison == ConditionComparison.ApproximateTo) 
-               && (Values == null ||Values.Length == 0))
+            if ( (Comparison == ConditionComparison.Equals ||
+                  Comparison == ConditionComparison.NotEquals ||
+                  Comparison == ConditionComparison.Contains ||
+                  Comparison == ConditionComparison.StartsWith ||
+                  Comparison == ConditionComparison.EndsWith ||
+                  Comparison == ConditionComparison.GreaterThan ||
+                  Comparison == ConditionComparison.LessThan ||
+                  Comparison == ConditionComparison.GreaterThanOrEquals ||
+                  Comparison == ConditionComparison.LessThanOrEquals ||
+                  Comparison == ConditionComparison.Matches ||
+                  Comparison == ConditionComparison.ApproximateTo) &&
+                 (Values == null || Values.Length == 0))
             {
                 throw new ValidationException("The condition values should be provided if comparison is not Exists or NotExists");
             }

--- a/src/Take.Blip.Builder/Models/Condition.cs
+++ b/src/Take.Blip.Builder/Models/Condition.cs
@@ -8,7 +8,7 @@ namespace Take.Blip.Builder.Models
     public class Condition : IValidable
     {
         /// <summary>
-        /// The source for comparison with the <see cref="Value"/>. Optional. The default value is <see cref="ValueSource.Input"/>.
+        /// The source for comparison with the <see cref="ValueSource"/>. Optional. The default value is <see cref="ValueSource.Input"/>.
         /// </summary>
         public ValueSource Source { get; set; }
 
@@ -33,9 +33,8 @@ namespace Take.Blip.Builder.Models
         public ConditionOperator Operator { get; set; }
 
         /// <summary>
-        /// The values to be used by the comparison with the context value. Required.
+        /// The values to be used by the comparison with the context value.
         /// </summary>
-        [Required(ErrorMessage = "The condition values are required")]
         public string[] Values { get; set; }
                
         public void Validate()
@@ -50,6 +49,27 @@ namespace Take.Blip.Builder.Models
             if (Source == ValueSource.Entity && string.IsNullOrWhiteSpace(Entity))
             {
                 throw new ValidationException("The entity name should be provided if the comparsion source is entity");
+            }
+
+            if ((Comparison == ConditionComparison.Exists || Comparison == ConditionComparison.NotExists) && (Values != null && Values.Length >= 0))
+            {
+                throw new ValidationException("The condition values should not be provided if comparison is Exists or NotExists");
+            }
+
+            if ( (Comparison == ConditionComparison.Equals 
+               || Comparison == ConditionComparison.NotEquals
+               || Comparison == ConditionComparison.Contains
+               || Comparison == ConditionComparison.StartsWith
+               || Comparison == ConditionComparison.EndsWith
+               || Comparison == ConditionComparison.GreaterThan
+               || Comparison == ConditionComparison.LessThan
+               || Comparison == ConditionComparison.GreaterThanOrEquals
+               || Comparison == ConditionComparison.LessThanOrEquals
+               || Comparison == ConditionComparison.Matches
+               || Comparison == ConditionComparison.ApproximateTo) 
+               && (Values == null ||Values.Length == 0))
+            {
+                throw new ValidationException("The condition values should be provided if comparison is not Exists or NotExists");
             }
         }
     }

--- a/src/Take.Blip.Builder/Models/ConditionComparison.cs
+++ b/src/Take.Blip.Builder/Models/ConditionComparison.cs
@@ -10,16 +10,6 @@ namespace Take.Blip.Builder.Models
     public enum ConditionComparison
     {
         /// <summary>
-        /// Check if value exists.
-        /// </summary>
-        Exists,
-        
-        /// <summary>
-        /// Check if value does not exist.
-        /// </summary>
-        NotExists,
-
-        /// <summary>
         /// Check for value equality.
         /// </summary>
         Equals,
@@ -73,6 +63,16 @@ namespace Take.Blip.Builder.Models
         /// Check if a string value is approximate to the other specified value.
         /// </summary>
         ApproximateTo,
+
+        /// <summary>
+        /// Check if value exists.
+        /// </summary>
+        Exists,
+
+        /// <summary>
+        /// Check if value does not exist.
+        /// </summary>
+        NotExists,
     }
 
     /// <summary>

--- a/src/Take.Blip.Builder/Models/ConditionComparison.cs
+++ b/src/Take.Blip.Builder/Models/ConditionComparison.cs
@@ -10,6 +10,16 @@ namespace Take.Blip.Builder.Models
     public enum ConditionComparison
     {
         /// <summary>
+        /// Check if value exists.
+        /// </summary>
+        Exists,
+        
+        /// <summary>
+        /// Check if value does not exist.
+        /// </summary>
+        NotExists,
+
+        /// <summary>
         /// Check for value equality.
         /// </summary>
         Equals,
@@ -65,9 +75,79 @@ namespace Take.Blip.Builder.Models
         ApproximateTo,
     }
 
+    /// <summary>
+    /// Define the delegation method for comparison types.
+    /// </summary>
+    public enum ComparisonType
+    {
+        /// <summary>
+        /// Check for unary comparison.
+        /// </summary>
+        Unary,
+
+        /// <summary>
+        /// Check for binary comparison.
+        /// </summary>
+        Binary,
+    }
+
     public static class ConditionComparisonExtensions
     {
-        public static Func<string, string, bool> ToDelegate(this ConditionComparison conditionComparison)
+        public static ComparisonType GetComparisonType(this ConditionComparison conditionComparison)
+        {
+            switch (conditionComparison)
+            {
+                case ConditionComparison.Exists:
+                case ConditionComparison.NotExists:
+                    return ComparisonType.Unary;
+
+                case ConditionComparison.Equals:
+                case ConditionComparison.NotEquals:
+                case ConditionComparison.Contains:
+                case ConditionComparison.StartsWith:
+                case ConditionComparison.EndsWith:
+                case ConditionComparison.GreaterThan:
+                case ConditionComparison.LessThan:
+                case ConditionComparison.GreaterThanOrEquals:
+                case ConditionComparison.LessThanOrEquals:
+                case ConditionComparison.Matches:
+                case ConditionComparison.ApproximateTo:
+                    return ComparisonType.Binary;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conditionComparison));
+            }
+        }
+
+        public static Func<string, bool> ToUnaryDelegate (this ConditionComparison conditionComparison)
+        {
+            switch (conditionComparison)
+            {
+                case ConditionComparison.Exists:
+                    return (v) => string.IsNullOrEmpty(v) == false;
+
+                case ConditionComparison.NotExists:
+                    return (v) => string.IsNullOrEmpty(v);
+                
+                case ConditionComparison.Equals:
+                case ConditionComparison.NotEquals:
+                case ConditionComparison.Contains:
+                case ConditionComparison.StartsWith:
+                case ConditionComparison.EndsWith:
+                case ConditionComparison.Matches:
+                case ConditionComparison.ApproximateTo:
+                case ConditionComparison.GreaterThan:
+                case ConditionComparison.LessThan:
+                case ConditionComparison.GreaterThanOrEquals:
+                case ConditionComparison.LessThanOrEquals:
+                    throw new ArgumentException("Not unary comparison condition: ", nameof(conditionComparison));
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conditionComparison));
+            }
+        }
+
+        public static Func<string, string, bool> ToBinaryDelegate(this ConditionComparison conditionComparison)
         {
             switch (conditionComparison)
             {
@@ -104,6 +184,10 @@ namespace Take.Blip.Builder.Models
 
                 case ConditionComparison.LessThanOrEquals:
                     return (v1, v2) => decimal.TryParse(v1, out var n1) && decimal.TryParse(v2, out var n2) && n1 <= n2;
+
+                case ConditionComparison.Exists:
+                case ConditionComparison.NotExists:
+                    throw new ArgumentException("Not binary comparison condition: ", nameof(conditionComparison));
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(conditionComparison));

--- a/src/Take.Blip.Client.UnitTests/Take.Blip.Client.UnitTests.csproj
+++ b/src/Take.Blip.Client.UnitTests/Take.Blip.Client.UnitTests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.3" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backlog Item: 110311 [Builder] Criar condição de saída "is set"

Commits:
Add Exists and NotExists conditions to output comparisons.
Update xUnit package version and fix ConditionComparison enum order. 
Add and refactor tests for Condition Comparison.
Add and refactor tests for Output Conditions.
Remove condition operator for unary comparison type.
Remove required from Values property for Condition. Add validation and fix Condition test.