### PR TITLE
Add a optional configuration to automatically add user identity in EventTrack extras

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/TrackEventActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/TrackEventActionTests.cs
@@ -199,7 +199,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
         }
 
         [Fact]
-        public async Task EventTrackWithDefaultExtrasShouldSucceed()
+        public async Task EventTrackWithUserIdExtrasConfigurationShouldSucceed()
         {
             // Arrange
             const string userIdentity = "user@domain.local";

--- a/src/Take.Blip.Builder/Actions/TrackEvent/TrackEventAction.cs
+++ b/src/Take.Blip.Builder/Actions/TrackEvent/TrackEventAction.cs
@@ -48,6 +48,8 @@ namespace Take.Blip.Builder.Actions.TrackEvent
                 extras = new Dictionary<string, string>();
             }
 
+            AddUserIdExtras(extras, context);
+
             var valueString = (string)settings[VALUE_KEY];
             decimal? value = null;
             if (!string.IsNullOrEmpty(valueString))
@@ -61,6 +63,22 @@ namespace Take.Blip.Builder.Actions.TrackEvent
             }
 
             await _eventTrackExtension.AddAsync(category, action, label:(string)settings[LABEL_KEY], value: value, messageId: messageId, extras: extras, cancellationToken: cancellationToken, contactIdentity: context.User);
+        }
+
+        /// <summary>
+        /// Add 'userId' to trackevent extras
+        /// </summary>
+        /// <param name="extras"></param>
+        /// <param name="context"></param>
+        private void AddUserIdExtras(Dictionary<string, string> extras, IContext context)
+        {
+            if (context.Flow?.Configuration != null && !extras.ContainsKey("userId") &&
+                context.Flow.Configuration.TryGetValue("trackEvent.addUserIdExtras", out string userIdExtrasValue) &&
+                bool.TryParse(userIdExtrasValue, out bool addUserIdExtras) &&
+                addUserIdExtras)
+            {
+                extras.Add("userId", context.User);
+            }
         }
     }
 }


### PR DESCRIPTION
It is useful because many times we want to know which user generated that EventTrack