### PR TITLE
Remove '.' from configuration variable name on ProcessHttpAction 

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
@@ -120,7 +120,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
         {
             //Arrange
             const string userIdentity = "user@domain.local";
-            const string userToRequestHeaderVariableName = "processHttp.addUserToRequestHeader";        
+            const string userToRequestHeaderVariableName = "processHttpAddUserToRequestHeader";        
             Context.Flow.Configuration.Add(userToRequestHeaderVariableName, "true");
             Context.User.Returns(Identity.Parse(userIdentity));
 

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -80,14 +80,14 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
 
         /// <summary>
         /// Add 'X-Blip-User' header to request, with current user identity as its value, if there is 
-        /// a configuration variable 'processHttp.addUserToRequestHeader' set to true
+        /// a configuration variable 'processHttpAddUserToRequestHeader' set to true
         /// </summary>
         /// <param name="httpRequestMessage"></param>
         /// <param name="context"></param>
         private void AddUserToHeaders(HttpRequestMessage httpRequestMessage, IContext context)
         {
             if (context.Flow.Configuration != null &&
-                context.Flow.Configuration.TryGetValue("processHttp.addUserToRequestHeader", out string userHeaderValue) && 
+                context.Flow.Configuration.TryGetValue("processHttpAddUserToRequestHeader", out string userHeaderValue) && 
                 bool.TryParse(userHeaderValue, out bool sendUserHeader) && 
                 sendUserHeader)
             {


### PR DESCRIPTION
Blip Portal does not allow separators as '.', '-, or '_' ...
Change to processHttpAddUserToRequestHeader