### PR TITLE
Action timeout and continue on error implementation

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/TrackEventActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/TrackEventActionTests.cs
@@ -67,7 +67,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var category = "categoryX";
             var action = "actionA";
             var label = "labelll";
-            decimal value = (decimal)45.78;
+            var value = 45.78M;
             var identity = Identity.Parse("myidentity@msging.net");
             var messageId = EnvelopeId.NewId();
             var extras = new Dictionary<string, string>()

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -1137,10 +1137,9 @@ namespace Take.Blip.Builder.UnitTests
             var input = new PlainText() { Text = "Ping!" };
             var messageType = "text/plain";
             var messageContent = "Pong!";
-
-            var timeoutMs = 16;
-            var timeout =  timeoutMs / 1000.0;
-            var fakeSender = new FakeSender(TimeSpan.FromMilliseconds(timeout * 2));            
+            
+            var timeout =  TimeSpan.FromMilliseconds(256);
+            var fakeSender = new FakeSender(timeout + timeout);            
             Sender = fakeSender;                                 
             var flow = new Flow()
             {
@@ -1168,7 +1167,7 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Timeout = timeout,
+                                Timeout = timeout.TotalSeconds,
                                 Settings = new JObject()
                                 {
                                     {"type", messageType},
@@ -1183,7 +1182,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(input, User, Application, flow, CancellationToken).ShouldThrowAsync<ActionProcessingException>();
-            exception.Message.ShouldBe($"The processing of the action 'SendMessage' has timed out after {timeoutMs} ms");
+            exception.Message.ShouldBe($"The processing of the action 'SendMessage' has timed out after {timeout.TotalMilliseconds} ms");
             fakeSender.SentMessages.ShouldBeEmpty();
         }
         

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -1161,7 +1161,7 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Timeout = 0.0000001, // Very small timeout to force cancellation
+                                Timeout = 0, // Very small timeout to force cancellation
                                 Settings = new JObject()
                                 {
                                     {"type", messageType},

--- a/src/Take.Blip.Builder/Actions/SetBucket/SetBucketSettings.cs
+++ b/src/Take.Blip.Builder/Actions/SetBucket/SetBucketSettings.cs
@@ -13,7 +13,7 @@ namespace Take.Blip.Builder.Actions.SetBucket
 
         public string Type { get; set; }
 
-        public int? Expiration { get; set; }
+        public double? Expiration { get; set; }
 
         public string Document { get; set; }
 

--- a/src/Take.Blip.Builder/Actions/SetVariable/SetVariableSettings.cs
+++ b/src/Take.Blip.Builder/Actions/SetVariable/SetVariableSettings.cs
@@ -10,7 +10,7 @@ namespace Take.Blip.Builder.Actions.SetVariable
 
         public string Value { get; set; }
 
-        public int? Expiration { get; set; }
+        public double? Expiration { get; set; }
 
         public void Validate()
         {

--- a/src/Take.Blip.Builder/Actions/TrackEvent/TrackEventSettings.cs
+++ b/src/Take.Blip.Builder/Actions/TrackEvent/TrackEventSettings.cs
@@ -20,7 +20,7 @@ namespace Take.Blip.Builder.Actions.TrackEvent
         {
             get
             {
-                if (decimal.TryParse(Value, out var parsedValue))
+                if (decimal.TryParse(Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsedValue))
                 {
                     return parsedValue;
                 }

--- a/src/Take.Blip.Builder/Diagnostics/ActionTrace.cs
+++ b/src/Take.Blip.Builder/Diagnostics/ActionTrace.cs
@@ -13,5 +13,8 @@ namespace Take.Blip.Builder.Diagnostics
 
         [DataMember(Name = "parsedSettings")]
         public JObject ParsedSettings { get; set; }
+        
+        [DataMember(Name = "continueOnError")]
+        public bool ContinueOnError { get; set; }
     }
 }

--- a/src/Take.Blip.Builder/Diagnostics/TraceManager.cs
+++ b/src/Take.Blip.Builder/Diagnostics/TraceManager.cs
@@ -86,7 +86,7 @@ namespace Take.Blip.Builder.Diagnostics
         {
             try
             {
-                using (var cts = new CancellationTokenSource(_configuration.TraceProcessingTimeout))
+                using (var cts = new CancellationTokenSource(_configuration.TraceTimeout))
                 {
                     await _traceProcessor.ProcessTraceAsync(traceEvent, cts.Token);
                 }

--- a/src/Take.Blip.Builder/Hosting/ConventionsConfiguration.cs
+++ b/src/Take.Blip.Builder/Hosting/ConventionsConfiguration.cs
@@ -29,6 +29,8 @@ namespace Take.Blip.Builder.Hosting
 
         public virtual string ContextType => nameof(ExtensionContext);
 
-        public TimeSpan ContactCacheExpiration => TimeSpan.FromMinutes(30);
+        public virtual TimeSpan ContactCacheExpiration => TimeSpan.FromMinutes(30);
+
+        public virtual TimeSpan DefaultActionExecutionTimeout => TimeSpan.FromSeconds(30);
     }
 }

--- a/src/Take.Blip.Builder/Hosting/ConventionsConfiguration.cs
+++ b/src/Take.Blip.Builder/Hosting/ConventionsConfiguration.cs
@@ -17,7 +17,7 @@ namespace Take.Blip.Builder.Hosting
 
         public virtual int TraceQueueMaxDegreeOfParalelism => 512;
 
-        public virtual TimeSpan TraceProcessingTimeout => TimeSpan.FromSeconds(5);
+        public virtual TimeSpan TraceTimeout => TimeSpan.FromSeconds(5);
 
         public virtual string RedisKeyPrefix => "builder";
 

--- a/src/Take.Blip.Builder/Hosting/IConfiguration.cs
+++ b/src/Take.Blip.Builder/Hosting/IConfiguration.cs
@@ -18,7 +18,7 @@ namespace Take.Blip.Builder.Hosting
 
         int TraceQueueMaxDegreeOfParalelism { get; }
 
-        TimeSpan TraceProcessingTimeout { get; }
+        TimeSpan TraceTimeout { get; }
 
         TimeSpan OnDemandCacheExpiration { get; }
 

--- a/src/Take.Blip.Builder/Hosting/IConfiguration.cs
+++ b/src/Take.Blip.Builder/Hosting/IConfiguration.cs
@@ -29,5 +29,7 @@ namespace Take.Blip.Builder.Hosting
         string ContextType { get; }
 
         TimeSpan ContactCacheExpiration { get; }
+        
+        TimeSpan DefaultActionExecutionTimeout { get; }
     }
 }

--- a/src/Take.Blip.Builder/Models/Action.cs
+++ b/src/Take.Blip.Builder/Models/Action.cs
@@ -25,6 +25,16 @@ namespace Take.Blip.Builder.Models
         /// Gets the timeout for executing the action, in seconds. Optional.
         /// </summary>
         public double? Timeout { get; set; }
+
+        /// <summary>
+        /// Indicates that the input processing should continue if any error occur in the action execution.
+        /// </summary>
+        public bool ContinueOnError { get; set; }
+
+        /// <summary>
+        /// TODO: Indicates if the action should be executed asynchronously, without blocking the input processing.
+        /// </summary>
+        public bool ExecuteAsynchronously { get; set; }
         
         /// <summary>
         /// The action type name. Required.
@@ -39,7 +49,7 @@ namespace Take.Blip.Builder.Models
 
         public void Validate()
         {
-            this.ValidateObject();
+            this.ValidateObject();           
         }
 
         public ActionTrace ToTrace()
@@ -47,14 +57,9 @@ namespace Take.Blip.Builder.Models
             return new ActionTrace
             {
                 Order = Order,
-                Type = Type
+                Type = Type,
+                ContinueOnError = ContinueOnError
             };
         }
-    }
-
-    public enum ActionExecutionMode
-    {
-        Synchronous,
-        Asynchronous
     }
 }

--- a/src/Take.Blip.Builder/Models/Action.cs
+++ b/src/Take.Blip.Builder/Models/Action.cs
@@ -22,6 +22,11 @@ namespace Take.Blip.Builder.Models
         public Condition[] Conditions { get; set; }
 
         /// <summary>
+        /// Gets the timeout for executing the action, in seconds. Optional.
+        /// </summary>
+        public double? Timeout { get; set; }
+        
+        /// <summary>
         /// The action type name. Required.
         /// </summary>
         [Required(ErrorMessage = "The action type is required")]
@@ -45,5 +50,11 @@ namespace Take.Blip.Builder.Models
                 Type = Type
             };
         }
+    }
+
+    public enum ActionExecutionMode
+    {
+        Synchronous,
+        Asynchronous
     }
 }


### PR DESCRIPTION
Changed the action processing to allow:
- Isolate timeouts by action
- A flag that indicates that the input processing should continue even in action failure