### PR TITLE
Optimize contact retrieval on Builder FlowManager

### DIFF
--- a/src/Samples/Builder.Console/BuilderMessageReceiver.cs
+++ b/src/Samples/Builder.Console/BuilderMessageReceiver.cs
@@ -1,26 +1,37 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Lime.Messaging.Resources;
 using Lime.Protocol;
 using Take.Blip.Builder;
 using Take.Blip.Client;
 using Take.Blip.Client.Activation;
+using Take.Blip.Client.Extensions.Contacts;
+using Take.Blip.Client.Extensions.Directory;
+using Take.Blip.Client.Receivers;
 
 namespace Builder.Console
 {
-    public class BuilderMessageReceiver : IMessageReceiver
+    public class BuilderMessageReceiver : ContactMessageReceiverBase
     {
         private readonly IFlowManager _flowManager;
         private readonly BuilderSettings _settings;
         private readonly Identity _applicationIdentity;
 
-        public BuilderMessageReceiver(IFlowManager flowManager, BuilderSettings settings, Application application)
+        public BuilderMessageReceiver(
+            IContactExtension contactExtension,
+            IDirectoryExtension directoryExtension,
+            IFlowManager flowManager,
+            BuilderSettings settings,
+            Application application)
+            : base(contactExtension, directoryExtension)
         {
             _flowManager = flowManager;
             _settings = settings;
             _applicationIdentity = $"{application.Identifier}@{application.Domain ?? Constants.DEFAULT_DOMAIN}";
         }
 
-        public virtual Task ReceiveAsync(Message envelope, CancellationToken cancellationToken) 
-            => _flowManager.ProcessInputAsync(envelope, _settings.Flow, cancellationToken);
+        protected override Task ReceiveAsync(Message message, Contact contact, CancellationToken cancellationToken)
+            => _flowManager.ProcessInputAsync(message, _settings.Flow, contact, cancellationToken);
+
     }
 }

--- a/src/Take.Blip.Builder.UnitTests/Actions/ActionConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ActionConditionsTests.cs
@@ -159,7 +159,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ActionProvider.Received().Get("ActionFistState");
@@ -197,7 +197,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ActionProvider.DidNotReceiveWithAnyArgs().Get(Arg.Any<string>());
@@ -244,7 +244,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ActionProvider.Received().Get("ActionFistState");
@@ -282,7 +282,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ActionProvider.DidNotReceiveWithAnyArgs().Get(Arg.Any<string>());

--- a/src/Take.Blip.Builder.UnitTests/Diagnostics/FlowTraceTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Diagnostics/FlowTraceTests.cs
@@ -80,7 +80,7 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await Task.Delay(100); // The trace is asynchronous
@@ -160,7 +160,7 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await Task.Delay(100); // The trace is asynchronous
@@ -290,7 +290,7 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
             // Act
             var input = new PlainText() { Text = "Ping!" };
             Message.Content = input;
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await Task.Delay(100); // The trace is asynchronous
@@ -423,7 +423,7 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
             // Act
             var input = new PlainText() { Text = "Ping!" };
             Message.Content = input;
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await Task.Delay(100); // The trace is asynchronous
@@ -508,7 +508,7 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
             // Act
             var input = new PlainText() { Text = "Ping!" };
             Message.Content = input;
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await Task.Delay(100); // The trace is asynchronous

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -69,7 +69,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -139,7 +139,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -209,7 +209,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -275,7 +275,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -318,7 +318,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -416,7 +416,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -596,7 +596,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(inputOk, flow, CancellationToken);
+            await target.ProcessInputAsync(inputOk, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "Start", Arg.Any<CancellationToken>());
@@ -774,7 +774,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(inputNOk, flow, CancellationToken);
+            await target.ProcessInputAsync(inputNOk, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "Start", Arg.Any<CancellationToken>());
@@ -901,8 +901,8 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(input1, flow, CancellationToken);
-            await target.ProcessInputAsync(input2, flow, CancellationToken);
+            await target.ProcessInputAsync(input1, flow, null, CancellationToken);
+            await target.ProcessInputAsync(input2, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -1026,7 +1026,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -1145,7 +1145,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -1214,7 +1214,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<ActionProcessingException>();
+            var exception = await target.ProcessInputAsync(Message, flow, null, CancellationToken).ShouldThrowAsync<ActionProcessingException>();
             exception.Message.ShouldBe($"The processing of the action 'SendMessage' has timed out after {timeout.TotalMilliseconds} ms");
             fakeSender.SentMessages.ShouldBeEmpty();
         }
@@ -1267,7 +1267,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             await target
-                .ProcessInputAsync(Message, flow, CancellationToken)
+                .ProcessInputAsync(Message, flow, null, CancellationToken)
                 .ShouldThrowAsync<ActionProcessingException>();           
         }        
         
@@ -1319,7 +1319,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);           
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);           
             
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);

--- a/src/Take.Blip.Builder.UnitTests/InputValidations/InputValidationsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/InputValidations/InputValidationsTests.cs
@@ -75,7 +75,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "state2", Arg.Any<CancellationToken>());
@@ -150,7 +150,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(0).SetStateIdAsync(Context, "state2", Arg.Any<CancellationToken>());
@@ -224,7 +224,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "state2", Arg.Any<CancellationToken>());
@@ -298,7 +298,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, Arg.Any<CancellationToken>());
+            await target.ProcessInputAsync(Message, flow, null, Arg.Any<CancellationToken>());
 
             // Assert
             StateManager.Received(0).SetStateIdAsync(Context, "state2", Arg.Any<CancellationToken>());
@@ -378,8 +378,8 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(invalidInputMessage, flow, CancellationToken);
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(invalidInputMessage, flow, null, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -467,8 +467,8 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(invalidInputMessage, flow, CancellationToken);
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(invalidInputMessage, flow, null, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -549,7 +549,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -623,7 +623,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             StateManager.Received(0).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());

--- a/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
@@ -96,7 +96,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await StateManager.Received(1).SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -195,7 +195,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             await StateManager.DidNotReceive().SetStateIdAsync(Context, "ping", Arg.Any<CancellationToken>());
@@ -275,7 +275,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(validInput);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
             
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Is<LazyInput>(i => i.Content == input), flow);
@@ -419,7 +419,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -453,7 +453,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -478,7 +478,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -512,7 +512,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -537,7 +537,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -571,7 +571,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -596,7 +596,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -630,7 +630,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -655,7 +655,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -689,7 +689,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Context.GetVariableAsync(variableName, Arg.Any<CancellationToken>()).Returns(input.Text);
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -713,7 +713,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -746,7 +746,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -770,7 +770,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);
@@ -803,7 +803,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             var target = GetTarget();
 
             // Act
-            await target.ProcessInputAsync(Message, flow, CancellationToken);
+            await target.ProcessInputAsync(Message, flow, null, CancellationToken);
 
             // Assert
             ContextProvider.Received(1).CreateContext(UserIdentity, ApplicationIdentity, Arg.Any<LazyInput>(), flow);

--- a/src/Take.Blip.Builder/Actions/MergeContact/MergeContactAction.cs
+++ b/src/Take.Blip.Builder/Actions/MergeContact/MergeContactAction.cs
@@ -26,7 +26,7 @@ namespace Take.Blip.Builder.Actions.MergeContact
             var contact = settings.ToObject<Contact>(LimeSerializerContainer.Serializer);
             contact.Identity = contact.Identity;
             await _contactExtension.MergeAsync(context.UserIdentity, contact, cancellationToken);
-            context.InputContext.Remove(nameof(contact));
+            context.RemoveContact();
         }
     }
 }

--- a/src/Take.Blip.Builder/ContextExtensions.cs
+++ b/src/Take.Blip.Builder/ContextExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Lime.Messaging.Resources;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Take.Blip.Builder
+{
+    public static class ContextExtensions
+    {
+        private const string CONTACT_KEY = "contact";
+
+        public static Contact GetContact(this IContext context)
+        {
+            return context.InputContext.TryGetValue(CONTACT_KEY, out var contact) ? (Contact)contact : null;
+        }
+
+        public static void SetContact(this IContext context, Contact contact)
+        {
+            RemoveContact(context);
+            context.InputContext[CONTACT_KEY] = contact;
+        }
+
+        public static void RemoveContact(this IContext context)
+        {
+            context.InputContext.Remove(CONTACT_KEY);
+        }
+    }
+}

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -1,4 +1,5 @@
 ﻿using Lime.Messaging.Contents;
+using Lime.Messaging.Resources;
 using Lime.Protocol;
 using Lime.Protocol.Serialization;
 using Newtonsoft.Json;
@@ -73,7 +74,7 @@ namespace Take.Blip.Builder
             _applicationIdentity = application.Identity;
         }
 
-        public async Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken)
+        public async Task ProcessInputAsync(Message message, Flow flow, Contact contact, CancellationToken cancellationToken)
         {
             if (message == null)
             {
@@ -147,6 +148,10 @@ namespace Take.Blip.Builder
 
                         // Load the user context
                         var context = _contextProvider.CreateContext(userIdentity, ownerIdentity, lazyInput, flow);
+                        if (contact != null)
+                        {
+                            context.SetContact(contact);
+                        }
 
                         // Try restore a stored state
                         var stateId = await _stateManager.GetStateIdAsync(context, linkedCts.Token);

--- a/src/Take.Blip.Builder/IFlowManager.cs
+++ b/src/Take.Blip.Builder/IFlowManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Lime.Messaging.Resources;
 using Lime.Protocol;
 using Take.Blip.Builder.Models;
 
@@ -15,8 +16,9 @@ namespace Take.Blip.Builder
         /// </summary>
         /// <param name="message">The input message.</param>
         /// <param name="flow">The builder flow.</param>
+        /// <param name="contact">The contact for the message sender, if available.</param>
         /// <param name="cancellationToken">The operation cancellation token.</param>
         /// <returns></returns>
-        Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken);
+        Task ProcessInputAsync(Message message, Flow flow, Contact contact, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/Variables/ContactVariableProvider.cs
+++ b/src/Take.Blip.Builder/Variables/ContactVariableProvider.cs
@@ -30,14 +30,11 @@ namespace Take.Blip.Builder.Variables
             Contact contact;
             try
             {
-                if (context.InputContext.TryGetValue(nameof(contact), out var contactValue))
-                {
-                    contact = (Contact)contactValue;
-                }
-                else
+                contact = context.GetContact();
+                if (contact == null)
                 {
                     contact = await _contactExtension.GetAsync(context.UserIdentity, cancellationToken);
-                    context.InputContext[nameof(contact)] = contact;
+                    context.SetContact(contact);
                 }
 
                 if (contact == null) return null;
@@ -46,7 +43,7 @@ namespace Take.Blip.Builder.Variables
             }
             catch (LimeException ex) when (ex.Reason.Code == ReasonCodes.COMMAND_RESOURCE_NOT_FOUND)
             {
-                context.InputContext[nameof(contact)] = null;
+                context.SetContact(null);
                 return null;
             }
         }


### PR DESCRIPTION
FlowManager now accepts an optional contact, so if the caller already has one it could be reused