### PR TITLE
Fix contact cache key generation

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTestsBase.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTestsBase.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Threading;
+using Lime.Messaging.Resources;
 using Lime.Protocol;
 using Lime.Protocol.Serialization;
 using NSubstitute;
@@ -31,6 +33,7 @@ namespace Take.Blip.Builder.UnitTests
             EventTrackExtension = Substitute.For<IEventTrackExtension>();
             BroadcastExtension = Substitute.For<IBroadcastExtension>();
             ContactExtension = Substitute.For<IContactExtension>();
+            TunnelExtension = Substitute.For<ITunnelExtension>();
             Sender = Substitute.For<ISender>();
             StateManager = Substitute.For<IStateManager>();
             ContextProvider = Substitute.For<IContextProvider>();
@@ -60,9 +63,9 @@ namespace Take.Blip.Builder.UnitTests
                 Substitute.For<IEnvelopeSerializer>(),
                 ArtificialIntelligenceExtension,
                 CancellationToken); 
-            Context.Input.Returns(Input);            
-            
-            TraceProcessor = Substitute.For<ITraceProcessor>();            
+            Context.Input.Returns(Input);
+
+            TraceProcessor = Substitute.For<ITraceProcessor>();
             OwnerCallerContactMap = new OwnerCallerContactMap();
             UserOwnerResolver = Substitute.For<IUserOwnerResolver>();
             UserOwnerResolver
@@ -89,7 +92,9 @@ namespace Take.Blip.Builder.UnitTests
         public IBroadcastExtension BroadcastExtension { get; set; }
 
         public IContactExtension ContactExtension { get; set; }
-        
+
+        public ITunnelExtension TunnelExtension { get; set; }
+
         public IOwnerCallerContactMap OwnerCallerContactMap { get; set; }
 
         public ISender Sender { get; set; }
@@ -118,6 +123,7 @@ namespace Take.Blip.Builder.UnitTests
             container.RegisterSingleton(EventTrackExtension);
             container.RegisterSingleton(BroadcastExtension);
             container.RegisterSingleton(ContactExtension);
+            container.RegisterSingleton(TunnelExtension);
             container.RegisterSingleton(OwnerCallerContactMap);
             container.RegisterSingleton(ContextProvider);
             container.RegisterSingleton(Sender);
@@ -132,6 +138,13 @@ namespace Take.Blip.Builder.UnitTests
         public IFlowManager GetTarget()
         {
             var container = CreateContainer();
+            return container.GetInstance<IFlowManager>();
+        }
+
+        public IFlowManager GetTarget(Action<Container> additionalSetup)
+        {
+            var container = CreateContainer();
+            additionalSetup(container);
             return container.GetInstance<IFlowManager>();
         }
     }

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -125,12 +125,7 @@ namespace Take.Blip.Builder
                 ? Stopwatch.StartNew()
                 : null;
 
-            // Sets the owner context if required
-            IDisposable ownerContext = null;
-            if (ownerIdentity != _applicationIdentity)
-            {
-                ownerContext = OwnerContext.Create(ownerIdentity);
-            }
+            var ownerContext = OwnerContext.Create(ownerIdentity);
             
             try
             {
@@ -275,8 +270,6 @@ namespace Take.Blip.Builder
                     inputTrace.Error = ex.ToString();
                 }
                 
-                ownerContext?.Dispose();
-
                 throw;
             }
             finally
@@ -285,6 +278,8 @@ namespace Take.Blip.Builder
                 {
                     await _traceManager.ProcessTraceAsync(inputTrace, traceSettings, inputStopwatch, cts.Token);
                 }
+
+                ownerContext.Dispose();
             }
         }
 


### PR DESCRIPTION
The key on `CacheContactExtensionDecorator` was missing the owner, hence allowing that different applications could reuse an existing contact if the user identity was the same.

