### PR TITLE
Change Jint to use the unnoficial version

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ExecuteScriptActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ExecuteScriptActionTests.cs
@@ -111,6 +111,37 @@ namespace Take.Blip.Builder.UnitTests.Actions
         }
 
         [Fact]
+        public async Task ExecuteUsingLetAndConstVariablesShouldHaveScopeAndSucceed()
+        {
+            // Arrange
+            var result = string.Empty;
+
+            var settings = new ExecuteScriptSettings()
+            {
+                InputVariables = Array.Empty<string>(),
+                Source = @"
+                    function scopedFunc() {
+                        let x = 1;
+                        const y = 'my value';
+                        return { x: x, y: y };
+                    }
+
+                    function run() {
+                        var scopedReturn = scopedFunc();
+                        return typeof x === 'undefined' && typeof y === 'undefined' && scopedReturn.x === 1 && scopedReturn.y === 'my value';
+                    }",
+                OutputVariable = nameof(result)
+            };
+            var target = GetTarget();
+
+            // Act
+            await target.ExecuteAsync(Context, JObject.FromObject(settings), CancellationToken);
+
+            // Assert
+            await Context.Received(1).SetVariableAsync(nameof(result), bool.TrueString.ToLowerInvariant(), CancellationToken);
+        }
+
+        [Fact]
         public async Task ExecuteWithCustomFunctionNameAndArgumentsShouldSucceed()
         {
             // Arrange

--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="3.0.0-beta-1710" />
     <PackageReference Include="SimpleInjector" Version="3.3.2" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="Take.Elephant.Redis" Version="0.6.221" />
+    <PackageReference Include="Take.Jint.Unnoficial" Version="3.0.0-beta-1716" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="Take.Elephant.Redis" Version="0.6.221" />
-    <PackageReference Include="Take.Jint.Unnoficial" Version="3.0.0-beta-1716" />
+    <PackageReference Include="Take.Jint.Unnoficial" Version="3.0.0-beta-1716001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This version fixes the bug where all the let and const variables are declared as global.
New jint(js interpreter): https://github.com/takenet/jint
New esprima(js parser): https://github.com/takenet/esprima-dotnet