### PR TITLE
Feature/add envelope buffer size property

### DIFF
--- a/src/Take.Blip.Client/Activation/Application.cs
+++ b/src/Take.Blip.Client/Activation/Application.cs
@@ -210,6 +210,8 @@ namespace Take.Blip.Client.Activation
         /// </summary>
         public bool RegisterTunnelReceivers { get; set; }
 
+        public int? EnvelopeBufferSize { get; set; }
+
         /// <summary>
         /// Creates an instance of <see cref="Application"/> from a JSON input.
         /// </summary>

--- a/src/Take.Blip.Client/Activation/Bootstrapper.cs
+++ b/src/Take.Blip.Client/Activation/Bootstrapper.cs
@@ -89,6 +89,8 @@ namespace Take.Blip.Client.Activation
             }
             if (application.PresenceStatus.HasValue) builder = builder.WithPresenceStatus(application.PresenceStatus.Value);
 
+            if (application.EnvelopeBufferSize.HasValue) builder = builder.WithEnvelopeBufferSize(application.EnvelopeBufferSize.Value);
+
             if (typeResolver == null) typeResolver = new TypeResolver();
             var localServiceProvider = BuildServiceProvider(application, typeResolver);
 

--- a/src/Take.Blip.Client/BlipClientBuilder.cs
+++ b/src/Take.Blip.Client/BlipClientBuilder.cs
@@ -239,8 +239,6 @@ namespace Take.Blip.Client
 
         public BlipClientBuilder WithEnvelopeBufferSize(int envelopeBufferSize)
         {
-            if (envelopeBufferSize < -1) throw new ArgumentOutOfRangeException(nameof(envelopeBufferSize));
-
             EnvelopeBufferSize = envelopeBufferSize;
             return this;
         }

--- a/src/Take.Blip.Client/BlipClientBuilder.cs
+++ b/src/Take.Blip.Client/BlipClientBuilder.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Lime.Messaging.Resources;
+﻿using Lime.Messaging.Resources;
 using Lime.Protocol;
 using Lime.Protocol.Client;
 using Lime.Protocol.Network;
 using Lime.Protocol.Network.Modules;
 using Lime.Protocol.Security;
 using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Take.Blip.Client
 {
@@ -43,8 +42,9 @@ namespace Take.Blip.Client
             RoundRobin = true;
             AutoNotify = true;
             ChannelCount = 1;
-            ReceiptEvents = new[] {Event.Accepted, Event.Dispatched, Event.Received, Event.Consumed, Event.Failed};
+            ReceiptEvents = new[] { Event.Accepted, Event.Dispatched, Event.Received, Event.Consumed, Event.Failed };
             PresenceStatus = PresenceStatus.Available;
+            EnvelopeBufferSize = 100;
         }
 
         public string Identifier { get; private set; }
@@ -92,6 +92,7 @@ namespace Take.Blip.Client
         public Event[] ReceiptEvents { get; private set; }
 
         public PresenceStatus PresenceStatus { get; private set; }
+        public int EnvelopeBufferSize { get; private set; }
 
         public BlipClientBuilder UsingPassword(string identifier, string password)
         {
@@ -236,6 +237,14 @@ namespace Take.Blip.Client
             return this;
         }
 
+        public BlipClientBuilder WithEnvelopeBufferSize(int envelopeBufferSize)
+        {
+            if (envelopeBufferSize < -1) throw new ArgumentOutOfRangeException(nameof(envelopeBufferSize));
+
+            EnvelopeBufferSize = envelopeBufferSize;
+            return this;
+        }
+
         /// <summary>
         /// Builds an <see cref="IBlipClient" /> with the configured parameters
         /// </summary>
@@ -244,7 +253,7 @@ namespace Take.Blip.Client
             var channelBuilder = ClientChannelBuilder
                 .Create(() => _transportFactory.Create(EndPoint), EndPoint)
                 .WithSendTimeout(SendTimeout)
-                .WithEnvelopeBufferSize(100)
+                .WithEnvelopeBufferSize(EnvelopeBufferSize)
                 .AddCommandModule(c => new ReplyPingChannelModule(c))
                 .AddBuiltHandler((c, t) =>
                 {
@@ -294,12 +303,12 @@ namespace Take.Blip.Client
 
             if (AccessKey != null)
             {
-                result = new KeyAuthentication {Key = AccessKey};
+                result = new KeyAuthentication { Key = AccessKey };
             }
 
             if (Token != null && Issuer != null)
             {
-                result = new ExternalAuthentication {Token = Token, Issuer = Issuer};
+                result = new ExternalAuthentication { Token = Token, Issuer = Issuer };
             }
 
             if (result == null)
@@ -341,7 +350,7 @@ namespace Take.Blip.Client
 
             await clientChannel.SetResourceAsync(
                     LimeUri.Parse(UriTemplates.RECEIPT),
-                    new Receipt {Events = ReceiptEvents},
+                    new Receipt { Events = ReceiptEvents },
                     cancellationToken)
                 .ConfigureAwait(false);
         }


### PR DESCRIPTION
Create a new property in BlipClientBuilder called EnvelopeBufferSize, so you can configure this parameter when building a new IBlipClient