### PR TITLE
Fix ProcessCommand action deserialization

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessCommandTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessCommandTests.cs
@@ -1,0 +1,141 @@
+﻿using Lime.Messaging.Contents;
+using Lime.Messaging.Resources;
+using Lime.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Take.Blip.Builder.Actions;
+using Take.Blip.Builder.Actions.ProcessCommand;
+using Take.Blip.Client;
+using Xunit;
+
+namespace Take.Blip.Builder.UnitTests.Actions
+{
+    public class ProcessCommandTests : ActionTestsBase
+    {
+        public ProcessCommandTests()
+        {
+            BlipClient = Substitute.For<ISender>();
+            Context.Flow.Returns(new Builder.Models.Flow { Configuration = new Dictionary<string, string>() });
+        }
+
+        public ISender BlipClient { get; set; }
+
+        private ProcessCommandAction GetTarget()
+        {
+            return new ProcessCommandAction(BlipClient, LimeSerializerContainer.EnvelopeSerializer);
+        }
+
+        [Fact]
+        public async Task ProcessGetActionShouldSucceed()
+        {
+            // Arrange
+            var command = new Command()
+            {
+                Id = EnvelopeId.NewId(),
+                Method = CommandMethod.Get,
+                Uri = new LimeUri("/ping")
+            };
+
+            var settings = JObject.FromObject(command, LimeSerializerContainer.Serializer);
+
+            var variable = "responseBody";
+            settings.TryAdd(nameof(variable), variable);
+
+            var target = GetTarget();
+
+            var responseCommand = new Command()
+            {
+                Method = CommandMethod.Get,
+                Status = CommandStatus.Success,
+                Resource = new JsonDocument()
+            };
+
+            BlipClient.ProcessCommandAsync(Arg.Any<Command>(), Arg.Any<CancellationToken>()).Returns(responseCommand);
+
+            // Act
+            await target.ExecuteAsync(Context, settings, CancellationToken);
+
+            // Assert
+            await BlipClient.Received(1).ProcessCommandAsync(Arg.Is<Command>(c => c.Uri.Equals(command.Uri)), Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variable, JsonConvert.SerializeObject(responseCommand, LimeSerializerContainer.Serializer.Converters.ToArray()), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ProcessSetPlainTextActionShouldSucceed()
+        {
+            // Arrange
+            var command = new Command()
+            {
+                Id = EnvelopeId.NewId(),
+                Method = CommandMethod.Set,
+                Uri = new LimeUri($"/contexts/{Context.UserIdentity}/somevariable"),
+                Resource = new PlainText { Text = "some value" }
+            };
+
+            var settings = JObject.FromObject(command, LimeSerializerContainer.Serializer);
+
+            var variable = "responseBody";
+            settings.TryAdd(nameof(variable), variable);
+
+            var target = GetTarget();
+
+            var responseCommand = new Command()
+            {
+                Method = CommandMethod.Set,
+                Status = CommandStatus.Success
+            };
+
+            BlipClient.ProcessCommandAsync(Arg.Any<Command>(), Arg.Any<CancellationToken>()).Returns(responseCommand);
+
+            // Act
+            await target.ExecuteAsync(Context, settings, CancellationToken);
+
+            // Assert
+            await BlipClient.Received(1).ProcessCommandAsync(Arg.Is<Command>(c => c.Uri.Equals(command.Uri)), Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variable, JsonConvert.SerializeObject(responseCommand, LimeSerializerContainer.Serializer.Converters.ToArray()), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ProcessMergeContactActionShouldSucceed()
+        {
+            // Arrange
+            var command = new Command()
+            {
+                Id = EnvelopeId.NewId(),
+                Method = CommandMethod.Merge,
+                Uri = new LimeUri($"/contacts"),
+                Resource = new Contact() { Identity = Context.UserIdentity, Address = "Nowhere St." }
+            };
+
+            var settings = JObject.FromObject(command, LimeSerializerContainer.Serializer);
+
+            var variable = "responseBody";
+            settings.TryAdd(nameof(variable), variable);
+
+            var target = GetTarget();
+
+            var responseCommand = new Command()
+            {
+                Method = CommandMethod.Merge,
+                Status = CommandStatus.Success
+            };
+
+            BlipClient.ProcessCommandAsync(Arg.Any<Command>(), Arg.Any<CancellationToken>()).Returns(responseCommand);
+
+            // Act
+            await target.ExecuteAsync(Context, settings, CancellationToken);
+
+            // Assert
+            await BlipClient.Received(1).ProcessCommandAsync(Arg.Is<Command>(c => c.Uri.Equals(command.Uri)), Arg.Any<CancellationToken>());
+
+            await Context.Received(1).SetVariableAsync(variable, JsonConvert.SerializeObject(responseCommand, LimeSerializerContainer.Serializer.Converters.ToArray()), Arg.Any<CancellationToken>());
+        }
+    }
+}

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -14,7 +14,7 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
         private readonly ISender _sender;
         private readonly IEnvelopeSerializer _envelopeSerializer;
 
-        private const string SERIALIZABLE_PATTERN = @".+[/|\+]json";
+        private const string SERIALIZABLE_PATTERN = @".+[/|\+]json$";
 
         public ProcessCommandAction(ISender sender, IEnvelopeSerializer envelopeSerializer)
         {

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -2,6 +2,7 @@
 using Lime.Protocol.Serialization;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Take.Blip.Client;
@@ -13,9 +14,7 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
         private readonly ISender _sender;
         private readonly IEnvelopeSerializer _envelopeSerializer;
 
-        private const string RESOURCE_KEY = "resource";
-        private const string RESOURCE_TYPE_KEY = "type";
-        private const string SERIALIZABLE_TYPE = "json";
+        private const string SERIALIZABLE_PATTERN = @".+[/|\+]json";
 
         public ProcessCommandAction(ISender sender, IEnvelopeSerializer envelopeSerializer)
         {
@@ -50,11 +49,11 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
         private Command ConvertToCommand(JObject settings)
         {
-            if (settings.TryGetValue(RESOURCE_TYPE_KEY, out var type)
-                && type.ToString().Contains(SERIALIZABLE_TYPE, StringComparison.OrdinalIgnoreCase)
-                && settings.TryGetValue(RESOURCE_KEY, out var resource))
+            if (settings.TryGetValue(Command.TYPE_KEY, out var type)
+                && Regex.IsMatch(type.ToString(), SERIALIZABLE_PATTERN)
+                && settings.TryGetValue(Command.RESOURCE_KEY, out var resource))
             {
-                settings.Property(RESOURCE_KEY).Value = JObject.Parse(resource.ToString());
+                settings.Property(Command.RESOURCE_KEY).Value = JObject.Parse(resource.ToString());
             }
             return settings.ToObject<Command>(LimeSerializerContainer.Serializer);
         }

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Lime.Protocol;
+﻿using Lime.Protocol;
 using Lime.Protocol.Serialization;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Take.Blip.Client;
 
 namespace Take.Blip.Builder.Actions.ProcessCommand
@@ -12,6 +12,10 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
     {
         private readonly ISender _sender;
         private readonly IEnvelopeSerializer _envelopeSerializer;
+
+        private const string RESOURCE_KEY = "resource";
+        private const string RESOURCE_TYPE_KEY = "type";
+        private const string SERIALIZABLE_TYPE = "json";
 
         public ProcessCommandAction(ISender sender, IEnvelopeSerializer envelopeSerializer)
         {
@@ -33,7 +37,7 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
                 variable = variableToken.ToString().Trim('"');
             }
 
-            var command = settings.ToObject<Command>(LimeSerializerContainer.Serializer);
+            var command = ConvertToCommand(settings);
             command.Id = EnvelopeId.NewId();
 
             var resultCommand = await _sender.ProcessCommandAsync(command, cancellationToken);
@@ -42,6 +46,17 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
             var resultCommandJson = _envelopeSerializer.Serialize(resultCommand);
             await context.SetVariableAsync(variable, resultCommandJson, cancellationToken);
+        }
+
+        private Command ConvertToCommand(JObject settings)
+        {
+            if (settings.TryGetValue(RESOURCE_TYPE_KEY, out var type)
+                && type.ToString().Contains(SERIALIZABLE_TYPE, StringComparison.OrdinalIgnoreCase)
+                && settings.TryGetValue(RESOURCE_KEY, out var resource))
+            {
+                settings.Property(RESOURCE_KEY).Value = JObject.Parse(resource.ToString());
+            }
+            return settings.ToObject<Command>(LimeSerializerContainer.Serializer);
         }
     }
 }


### PR DESCRIPTION
Fix error when deserializing the `ProcessCommand` action to `Command` when the resource come as a `json` stringified value.

- Extract the parsing logic to a private method;
- Check if the current `resource` `type` is a serializable type, i.e. has `json` on it's value and parse to `JObject` before parsing to `Command`