### PR TITLE
adding type:project to the tempalte.json files

### DIFF
--- a/src/Templates/Take.Blip.Client.ConsoleTemplate/.template.config/template.json
+++ b/src/Templates/Take.Blip.Client.ConsoleTemplate/.template.config/template.json
@@ -5,8 +5,9 @@
     "identity": "Take.Blip.Client.ConsoleTemplate",
     "shortName": "blip-console",
     "tags": {
-        "language": "C#"
-    },
+        "language": "C#",
+        "type": "project"
+      },
     "sourceName": "Take.Blip.Client.ConsoleTemplate",
     "preferNameDirectory": true
 }

--- a/src/Templates/Take.Blip.Client.WebTemplate/.template.config/template.json
+++ b/src/Templates/Take.Blip.Client.WebTemplate/.template.config/template.json
@@ -5,7 +5,8 @@
   "identity": "Take.Blip.Client.WebTemplate",
   "shortName": "blip-web",
   "tags": {
-    "language": "C#"
+    "language": "C#",
+    "type":"project"
   },
   "sourceName": "Take.Blip.Client.WebTemplate",
   "preferNameDirectory": true


### PR DESCRIPTION
I have modified the `template.json` files for your two project templates. I added `"type":"project"` to the tags section.

We are going to be showing templates installed via `dotnet new --install` in Visual Studio, for more info see [this blog post](https://devblogs.microsoft.com/dotnet/net-cli-templates-in-visual-studio/). Since your templates did not specify `"type":"project"` in tags it was not appearing in the New Project Dialog in Visual Studio. The changes here should enable your templates to appear.

Here is what your templates look like in Visual Studio after I made these changes.

![image](https://user-images.githubusercontent.com/1283154/96182227-2da46880-0f03-11eb-8043-4b09dda442a3.png)

Some things you may want to consider to further improve the experiecne.

### Add an icon for each template

To do this, you should add a file named `ide.host.json` to each `.template.config` and add the icon property. See this example https://github.com/sayedihashimi/template-sample/blob/main/src/Content/MyCommand/.template.config/ide.host.json. The image file will need to be in, or under, the `template.config` folder.

### Add a default name

When a user creates a new project in Visual Studio the default name used is `Project1`. You may want to provide a better default name. If so add the `defaultName` property to your `template.json`. See this example https://github.com/sayedihashimi/template-sample/blob/main/src/Content/MyCommand/.template.config/template.json

### Add some more `classifications`

For `classifications` in `template.json`, I would recommend adding `Console` for your console template and `Web` for your web template. These can be used as a filter in Visual Studio when creating a new project in the "All project types" dropdown.

### Add `framework` property

You may want to list indicate what framework will be used when creating this project. Currently it's not easy to figure out what framework version will be used when going through New Project in Visual Studio. To indicate the framework version see this example https://github.com/sayedihashimi/template-sample/blob/main/src/Content/MyCommand/.template.config/template.json. After adding this the framework dropdown will appear in Visual Studio. If your template supports only one framework version, that will be the only option in the dropdown when shown.

FYI I will monitor this for any comments, but you can also reach me on twitter at [@SayedIHashimi](https://twitter.com/sayedihashimi) if you have any questions.