### PR TITLE
bugfix: action timeout should work on a single action, not on the entire flow

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
@@ -240,7 +240,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
             HttpClient.SendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
                 .Returns(async token =>
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(20), token.Arg<CancellationToken>());
+                    await Task.Delay(TimeSpan.FromMilliseconds(20), token.Arg<CancellationToken>());
                     return Substitute.For<HttpResponseMessage>();
                 });
 

--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessHttpActionTests.cs
@@ -238,14 +238,14 @@ namespace Take.Blip.Builder.UnitTests.Actions
             var target = GetTarget();
 
             HttpClient.SendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
-                .Returns(async x =>
+                .Returns(async token =>
                 {
-                    await Task.Delay(20001, x.Arg<CancellationToken>());
+                    await Task.Delay(TimeSpan.FromSeconds(20), token.Arg<CancellationToken>());
                     return Substitute.For<HttpResponseMessage>();
                 });
 
             // Act
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(10)))
                 await target.ExecuteAsync(Context, JObject.FromObject(settings), cts.Token);
 
             //Assert

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -64,24 +64,25 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
                         }
                     }
                 }
+
+            //Set the responses variables
+            if (!string.IsNullOrWhiteSpace(settings.ResponseStatusVariable))
+                {
+                    await context.SetVariableAsync(settings.ResponseStatusVariable,
+                        responseStatus.ToString(), cancellationToken);
+                }
+
+                if (!string.IsNullOrWhiteSpace(settings.ResponseBodyVariable) &&
+                    !string.IsNullOrWhiteSpace(responseBody))
+                {
+                    await context.SetVariableAsync(settings.ResponseBodyVariable, responseBody, cancellationToken);
+                }
             }
             catch (Exception ex)
             {
                 _logger.Warning(ex, $"An exception occurred while processing HTTP action");
             }
 
-            // Set the responses variables
-            if (!string.IsNullOrWhiteSpace(settings.ResponseStatusVariable))
-            {
-                await context.SetVariableAsync(settings.ResponseStatusVariable,
-                    responseStatus.ToString(), cancellationToken);
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.ResponseBodyVariable) &&
-                !string.IsNullOrWhiteSpace(responseBody))
-            {
-                await context.SetVariableAsync(settings.ResponseBodyVariable, responseBody, cancellationToken);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Made changes so the flow continues with a warning after action timeout 

- Added unit test to verify the flow will go on after action timeout 