### PR TITLE
Feature/content assistant

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Actions/ProcessContentAssistantTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ProcessContentAssistantTests.cs
@@ -1,0 +1,82 @@
+﻿using Newtonsoft.Json.Linq;
+using NSubstitute;
+using System;
+using System.Threading.Tasks;
+using Take.Blip.Builder.Actions.ProcessContentAssistant;
+using Take.Blip.Client.Extensions.ArtificialIntelligence;
+using Takenet.Iris.Messaging.Resources.ArtificialIntelligence;
+using Xunit;
+
+namespace Take.Blip.Builder.UnitTests.Actions
+{
+    public class ProcessContentAssistantTests : ActionTestsBase
+    {
+        private readonly IArtificialIntelligenceExtension _artificialIntelligenceExtension = Substitute.For<IArtificialIntelligenceExtension>();
+        private readonly ProcessContentAssistantAction _processContentAssistantAction;
+
+        public ProcessContentAssistantTests()
+        {
+            _processContentAssistantAction = new ProcessContentAssistantAction(_artificialIntelligenceExtension);
+        }
+
+        [Fact]
+        public async Task ValidContentAssistantRequest_ShouldSucceedAsync()
+        {
+            //Arrange
+            var minimumIntentScore = 0.5;
+            var settings = new ProcessContentAssistantSettings
+            {
+                Text = "Test case"
+            };
+
+            Context.Flow.BuilderConfiguration.MinimumIntentScore = minimumIntentScore;
+
+            var contentAssistantResource = new AnalysisRequest
+            {
+                Text = settings.Text,
+                Score = Context.Flow.BuilderConfiguration.MinimumIntentScore ?? default
+            };
+
+            //Act
+            await _processContentAssistantAction.ExecuteAsync(Context, JObject.FromObject(settings), CancellationToken);
+
+            //Assert
+            await _artificialIntelligenceExtension.Received(1).GetContentResultAsync(Arg.Is<AnalysisRequest>(a => a.Text == settings.Text && a.Score == minimumIntentScore), cancellationToken: CancellationToken);
+        }
+
+        [Fact]
+        public async Task ValidContentAssistantRequestWithoutScore_ShouldSucceedAsync()
+        {
+            //Arrange
+            var settings = new ProcessContentAssistantSettings
+            {
+                Text = "Test case"
+            };
+            var contentAssistantResource = new AnalysisRequest
+            {
+                Text = settings.Text
+            };
+
+            //Act
+            await _processContentAssistantAction.ExecuteAsync(Context, JObject.FromObject(settings), CancellationToken);
+
+            //Assert
+            await _artificialIntelligenceExtension.Received(1).GetContentResultAsync(Arg.Is<AnalysisRequest>(a => a.Text == settings.Text), cancellationToken: CancellationToken);
+        }
+
+        [Fact]
+        public async Task ValidContentAssistantRequestWithoutText_ShouldFailAsync()
+        {
+            //Arrange
+            var minimumIntentScore = 0.5;
+            var settings = new ProcessContentAssistantSettings();
+            Context.Flow.BuilderConfiguration.MinimumIntentScore = minimumIntentScore;
+
+            //Act
+            Action functionCall = () => _processContentAssistantAction.ExecuteAsync(Context, JObject.FromObject(settings), CancellationToken);
+
+            //Assert
+            Assert.Throws<ArgumentException>(functionCall);
+        }
+    }
+}

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
@@ -28,11 +28,11 @@ namespace Take.Blip.Builder.Actions.ProcessContentAssistant
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public override async Task ExecuteAsync(IContext context, ProcessContentAssistantSettings settings, CancellationToken cancellationToken)
-        {
+        {   
             var contentAssistantResource = new AnalysisRequest
             {
                 Text = settings.Text,
-                Score = context.Flow.BuilderConfiguration.MinimumIntentScore ?? default
+                Score = settings.Score.HasValue ? settings.Score.Value : context.Flow.BuilderConfiguration.MinimumIntentScore.Value 
             } as Document;
 
             var contentResult = await _artificialIntelligenceExtension.GetContentResultAsync(

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
@@ -35,7 +35,7 @@ namespace Take.Blip.Builder.Actions.ProcessContentAssistant
             var contentAssistantResource = new AnalysisRequest
             {
                 Text = settings.Text,
-                Score = settings.Score ?? context.Flow.BuilderConfiguration.MinimumIntentScore.Value / Constants.PERCENTAGE_DENOMINATOR
+                Score = settings.Score.HasValue ? settings.Score.Value/Constants.PERCENTAGE_DENOMINATOR : context.Flow.BuilderConfiguration.MinimumIntentScore.Value
             } as Document;
 
             var contentResult = await _artificialIntelligenceExtension.GetContentResultAsync(

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
@@ -1,5 +1,6 @@
 ﻿using Lime.Protocol;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,23 +43,23 @@ namespace Take.Blip.Builder.Actions.ProcessContentAssistant
                 contentAssistantResource,
                 cancellationToken: cancellationToken);
 
-            await SetContentResultAsync(context, settings, contentResult, cancellationToken);
+            await SetContentResultAsync(context, settings.OutputVariable, contentResult, cancellationToken);
         }
 
         private async Task SetContentResultAsync(
-          IContext context, ProcessContentAssistantSettings settings, ContentResult contentResult, CancellationToken cancellationToken)
+          IContext context, string outputVariable, ContentResult contentResult, CancellationToken cancellationToken)
         {
             var combinationFound = contentResult.Combinations?.FirstOrDefault();
 
             var value = JsonConvert.SerializeObject(new ContentAssistantActionResponse
             {
                 HasCombination = contentResult?.Result?.Content != null,
-                Value = contentResult?.Result?.Content?.ToString(),
-                Intent = combinationFound?.Intent,
-                Entities = combinationFound?.Entities.ToList()
+                Value = contentResult?.Result?.Content?.ToString() ?? string.Empty,
+                Intent = combinationFound?.Intent ?? string.Empty,
+                Entities = combinationFound?.Entities.ToList() ?? new List<string>()
             });
 
-            await context.SetVariableAsync(settings.OutputVariable, value, cancellationToken);
+            await context.SetVariableAsync(outputVariable, value, cancellationToken);
         }
 
     }

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
@@ -1,0 +1,62 @@
+﻿using Lime.Protocol;
+using System.Threading;
+using System.Threading.Tasks;
+using Take.Blip.Client.Extensions.ArtificialIntelligence;
+using Takenet.Iris.Messaging.Resources.ArtificialIntelligence;
+
+namespace Take.Blip.Builder.Actions.ProcessContentAssistant
+{
+    /// <summary>
+    /// Content Assistant action
+    /// </summary>
+    public class ProcessContentAssistantAction : ActionBase<ProcessContentAssistantSettings>
+    {
+        private readonly IArtificialIntelligenceExtension _artificialIntelligenceExtension;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public ProcessContentAssistantAction(IArtificialIntelligenceExtension artificialIntelligenceExtension) : base(nameof(ProcessContentAssistant))
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+        {
+            _artificialIntelligenceExtension = artificialIntelligenceExtension;
+        }
+
+        /// <summary>
+        /// Get content result to a given input
+        /// </summary>
+        /// <param name="context">bot context</param>
+        /// <param name="settings">ContentAssistant settings</param 
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public override async Task ExecuteAsync(IContext context, ProcessContentAssistantSettings settings, CancellationToken cancellationToken)
+        {
+            var contentAssistantResource = new AnalysisRequest
+            {
+                Text = settings.Text,
+                Score = context.Flow.BuilderConfiguration.MinimumIntentScore ?? default
+            } as Document;
+
+            var contentResult = await _artificialIntelligenceExtension.GetContentResultAsync(
+                contentAssistantResource,
+                cancellationToken: cancellationToken);
+
+            await SetContentResultAsync(context, settings, contentResult, cancellationToken);
+
+        }
+
+        private async Task SetContentResultAsync(
+          IContext context, ProcessContentAssistantSettings settings, ContentResult contentResult, CancellationToken cancellationToken)
+        {
+            if (contentResult?.Result?.Content != null)
+            {
+                var value = contentResult.Result.Content.ToString();
+
+                await context.SetVariableAsync(settings.OutputVariable, value, cancellationToken);
+            }
+            else
+            {
+                await context.DeleteVariableAsync(settings.OutputVariable, cancellationToken);
+            }
+        }
+
+    }
+}

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantSettings.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantSettings.cs
@@ -15,6 +15,11 @@ namespace Take.Blip.Builder.Actions.ProcessContentAssistant
         /// </summary>
         public string OutputVariable { get; set; }
 
+        /// <summary>
+        /// Minimum intent score
+        /// </summary>
+        public double? Score { get; set; }
+
         public void Validate()
         {
             if (string.IsNullOrEmpty(Text))

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantSettings.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantSettings.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Take.Blip.Builder.Models;
+
+namespace Take.Blip.Builder.Actions.ProcessContentAssistant
+{
+    public class ProcessContentAssistantSettings : IValidable
+    {
+        /// <summary>
+        /// Sentence to be analyzed
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Output variable
+        /// </summary>
+        public string OutputVariable { get; set; }
+
+        public void Validate()
+        {
+            if (string.IsNullOrEmpty(Text))
+            {
+                throw new ArgumentException($"The '{nameof(Text)}' settings value is required for '{nameof(ProcessContentAssistantSettings)}' action");
+            }
+            if (string.IsNullOrEmpty(OutputVariable))
+            {
+                throw new ArgumentException($"The '{nameof(OutputVariable)}' settings value is required for '{nameof(ProcessContentAssistantSettings)}' action");
+            }
+        }
+    }
+}

--- a/src/Take.Blip.Builder/Constants.cs
+++ b/src/Take.Blip.Builder/Constants.cs
@@ -35,5 +35,10 @@ namespace Take.Blip.Builder
             "yyyy-MM-ddTHH:mm:ssK",
             "yyyy-dd-MMTHH:mm:ssK"
         };
+
+        /// <summary>
+        /// Denominator percentage
+        /// </summary>
+        public const int PERCENTAGE_DENOMINATOR = 100;
     }
 }

--- a/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
+++ b/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
@@ -12,6 +12,7 @@ using Take.Blip.Builder.Actions.ForwardMessageToDesk;
 using Take.Blip.Builder.Actions.ManageList;
 using Take.Blip.Builder.Actions.MergeContact;
 using Take.Blip.Builder.Actions.ProcessCommand;
+using Take.Blip.Builder.Actions.ProcessContentAssistant;
 using Take.Blip.Builder.Actions.ProcessHttp;
 using Take.Blip.Builder.Actions.Redirect;
 using Take.Blip.Builder.Actions.SendCommand;
@@ -82,7 +83,8 @@ namespace Take.Blip.Builder.Hosting
                     typeof(RedirectAction),
                     typeof(ForwardMessageToDeskAction),
                     typeof(CreateTicketAction),
-                    typeof(DeleteVariableAction)
+                    typeof(DeleteVariableAction),
+                    typeof(ProcessContentAssistantAction)
                 });
 
             return container;

--- a/src/Take.Blip.Builder/Models/ContentAssistantActionResponse.cs
+++ b/src/Take.Blip.Builder/Models/ContentAssistantActionResponse.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Take.Blip.Builder.Models
+{
+    /// <summary>
+    /// ContentAssistant resposne object
+    /// </summary>
+    public class ContentAssistantActionResponse
+    {
+        /// <summary>
+        /// Bool that indicates if there's a combination found
+        /// </summary>
+        public bool HasCombination { get; set; }
+
+        /// <summary>
+        /// Response found for combination
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// IntentFound
+        /// </summary>
+        public string Intent { get; set; }
+
+        /// <summary>
+        /// Entities found
+        /// </summary>
+        public List<string> Entities { get; set; }
+    }
+}

--- a/src/Take.Blip.Client/Extensions/ArtificialIntelligence/ArtificialIntelligenceExtension.cs
+++ b/src/Take.Blip.Client/Extensions/ArtificialIntelligence/ArtificialIntelligenceExtension.cs
@@ -1,11 +1,9 @@
-﻿using System;
+﻿using Lime.Protocol;
+using SmartFormat;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Lime.Protocol;
-using SmartFormat;
 using Takenet.Iris.Messaging.Resources.ArtificialIntelligence;
 
 namespace Take.Blip.Client.Extensions.ArtificialIntelligence
@@ -25,11 +23,26 @@ namespace Take.Blip.Client.Extensions.ArtificialIntelligence
                     analysisRequest, UriTemplates.ANALYSIS, ArtificialIntelligenceAddress),
                 cancellationToken);
 
-        public Task<ContentResult> GetContentResultAsync(Document document, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<ContentResult> GetContentResultAsync(Document document, CancellationToken cancellationToken = default)
             => ProcessCommandAsync<ContentResult>(
                 CreateSetCommandRequest(
                     document, UriTemplates.CONTENT_ANALYSIS, ArtificialIntelligenceAddress),
                 cancellationToken);
+
+        public Task<ContentResult> GetContentResultAsync(string input, double minimumIntentScore, CancellationToken cancellationToken = default)
+        {
+            var analysisRequest = new AnalysisRequest
+            {
+                Text = input,
+                Score = minimumIntentScore
+            };
+
+            return ProcessCommandAsync<ContentResult>(
+                CreateSetCommandRequest(
+                    analysisRequest, UriTemplates.CONTENT_ANALYSIS, ArtificialIntelligenceAddress),
+           cancellationToken);
+
+        }
 
         public Task SendFeedbackAsync(string analysisId, AnalysisFeedback analysisFeedback,
             CancellationToken cancellationToken = new CancellationToken())

--- a/src/Take.Blip.Client/Extensions/ArtificialIntelligence/ArtificialIntelligenceExtension.cs
+++ b/src/Take.Blip.Client/Extensions/ArtificialIntelligence/ArtificialIntelligenceExtension.cs
@@ -29,20 +29,6 @@ namespace Take.Blip.Client.Extensions.ArtificialIntelligence
                     document, UriTemplates.CONTENT_ANALYSIS, ArtificialIntelligenceAddress),
                 cancellationToken);
 
-        public Task<ContentResult> GetContentResultAsync(string input, double minimumIntentScore, CancellationToken cancellationToken = default)
-        {
-            var analysisRequest = new AnalysisRequest
-            {
-                Text = input,
-                Score = minimumIntentScore
-            };
-
-            return ProcessCommandAsync<ContentResult>(
-                CreateSetCommandRequest(
-                    analysisRequest, UriTemplates.CONTENT_ANALYSIS, ArtificialIntelligenceAddress),
-           cancellationToken);
-
-        }
 
         public Task SendFeedbackAsync(string analysisId, AnalysisFeedback analysisFeedback,
             CancellationToken cancellationToken = new CancellationToken())

--- a/src/Take.Blip.Client/Extensions/ArtificialIntelligence/IArtificialIntelligenceExtension.cs
+++ b/src/Take.Blip.Client/Extensions/ArtificialIntelligence/IArtificialIntelligenceExtension.cs
@@ -173,7 +173,5 @@ namespace Take.Blip.Client.Extensions.ArtificialIntelligence
         /// <returns></returns>
         Task SendFeedbackAsync(string analysisId, AnalysisFeedback analysisFeedback, CancellationToken cancellationToken = default(CancellationToken));
 
-
-        Task<ContentResult> GetContentResultAsync(string input, double minimumIntentScore, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Take.Blip.Client/Extensions/ArtificialIntelligence/IArtificialIntelligenceExtension.cs
+++ b/src/Take.Blip.Client/Extensions/ArtificialIntelligence/IArtificialIntelligenceExtension.cs
@@ -172,5 +172,8 @@ namespace Take.Blip.Client.Extensions.ArtificialIntelligence
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task SendFeedbackAsync(string analysisId, AnalysisFeedback analysisFeedback, CancellationToken cancellationToken = default(CancellationToken));
+
+
+        Task<ContentResult> GetContentResultAsync(string input, double minimumIntentScore, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Process Content Assistant Action

Add contentAssistant action in builder to allow request to be made with variables instead of just user input

- Add: ContentAssistantSettings
- Add: ContentAssistantAction unit tests
- Add: Score treatment on ProcessContentAssistantAction
- Add: Return object (ContentAssistantActionResponse) instead of just response text
- Add: Score value conversion to percentage in ContentAssistantAction
- Add: Conversor for percentage value of score
- Add: Content AssistantAction tests
- Refac: remove unused methods
- Add: Test case for when there's no combination found for given question