### PR TITLE
Add message internal Id to notification metada

### DIFF
--- a/src/Take.Blip.Client.UnitTests/BlipChannelListenerTests.cs
+++ b/src/Take.Blip.Client.UnitTests/BlipChannelListenerTests.cs
@@ -181,7 +181,7 @@ namespace Take.Blip.Client.UnitTests
             var notification = message.ToReceivedNotification();
 
             // Assert
-            notification.Metadata.ShouldContainKeyAndValue("#message.uniqueId", message.Metadata["$internalId"]);
+            notification.Metadata.ShouldContainKeyAndValue("#message.uniqueId", message.Metadata["#uniqueId"]);
         }
 
         [Fact]
@@ -189,7 +189,7 @@ namespace Take.Blip.Client.UnitTests
         {
             // Arrange
             var message = Dummy.CreateMessage();
-            message.Metadata.Remove("$internalId");
+            message.Metadata.Remove("#uniqueId");
 
             // Act            
             var notification = message.ToReceivedNotification();

--- a/src/Take.Blip.Client.UnitTests/BlipChannelListenerTests.cs
+++ b/src/Take.Blip.Client.UnitTests/BlipChannelListenerTests.cs
@@ -171,5 +171,31 @@ namespace Take.Blip.Client.UnitTests
             textMessageReceiver2.Received(1).ReceiveAsync(textMessage2, Arg.Any<CancellationToken>());
             textMessageReceiver2.DidNotReceive().ReceiveAsync(textMessage1, Arg.Any<CancellationToken>());
         }
+
+        [Fact]
+        public void MessageToNotificationWithInternalIdShouldBeValid()
+        {
+            // Arrange
+            var message = Dummy.CreateMessage();
+            // Act
+            var notification = message.ToReceivedNotification();
+
+            // Assert
+            notification.Metadata.ShouldContainKeyAndValue("#message.uniqueId", message.Metadata["$internalId"]);
+        }
+
+        [Fact]
+        public void MessageToNotificationWithNoInternalIdShouldBeNull()
+        {
+            // Arrange
+            var message = Dummy.CreateMessage();
+            message.Metadata.Remove("$internalId");
+
+            // Act            
+            var notification = message.ToReceivedNotification();
+
+            // Assert
+            notification.Metadata.ShouldContainKeyAndValue("#message.uniqueId", null);
+        }
     }
 }

--- a/src/Take.Blip.Client.UnitTests/Dummy.cs
+++ b/src/Take.Blip.Client.UnitTests/Dummy.cs
@@ -102,6 +102,14 @@ namespace Take.Blip.Client.UnitTests
             };
         }
 
+        public static Dictionary<string, string> CreateMetadata()
+        {
+            return new Dictionary<string, string>()
+            {
+                { "$internalId", Guid.NewGuid().ToString() }
+            };
+        }
+
         public static LimeUri CreateAbsoluteLimeUri()
         {
             return new LimeUri(
@@ -202,7 +210,8 @@ namespace Take.Blip.Client.UnitTests
                 Id = EnvelopeId.NewId(),
                 From = CreateNode(),
                 To = CreateNode(),
-                Content = content
+                Content = content,
+                Metadata = CreateMetadata()
             };
         }
 

--- a/src/Take.Blip.Client.UnitTests/Dummy.cs
+++ b/src/Take.Blip.Client.UnitTests/Dummy.cs
@@ -106,7 +106,7 @@ namespace Take.Blip.Client.UnitTests
         {
             return new Dictionary<string, string>()
             {
-                { "$internalId", Guid.NewGuid().ToString() }
+                { "#uniqueId", Guid.NewGuid().ToString() }
             };
         }
 

--- a/src/Take.Blip.Client/MessageExtensions.cs
+++ b/src/Take.Blip.Client/MessageExtensions.cs
@@ -29,7 +29,7 @@ namespace Take.Blip.Client
             Metadata = new Dictionary<string, string>
             {
                 { "#message.to", message.To },
-                { "#message.uniqueId", message.GetMetadataKeyValue("$internalId")}
+                { "#message.uniqueId", message.GetMetadataKeyValue("#uniqueId")}
             }
         };
 

--- a/src/Take.Blip.Client/MessageExtensions.cs
+++ b/src/Take.Blip.Client/MessageExtensions.cs
@@ -28,8 +28,19 @@ namespace Take.Blip.Client
             Event = @event,
             Metadata = new Dictionary<string, string>
             {
-                { "#message.to", message.To }
+                { "#message.to", message.To },
+                { "#message.uniqueId", message.GetMetadataKeyValue("$internalId")}
             }
         };
+
+        private static string GetMetadataKeyValue(this Envelope envelope, string key)
+        {
+            if (envelope.Metadata == null)
+            { 
+                return null;
+            }
+            envelope.Metadata.TryGetValue(key, out var value);
+            return value;
+        }
     }
 }


### PR DESCRIPTION

We inserted this metadata to be able to back up messages and notifications without ID