### PR TITLE
Update SimpleInjector to 5.3.2 and respond to breaking changes accordingly

### DIFF
--- a/src/Samples/Builder.Console/Builder.Console.csproj
+++ b/src/Samples/Builder.Console/Builder.Console.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="4.0.12" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Builder.Console/BuilderServiceProvider.cs
+++ b/src/Samples/Builder.Console/BuilderServiceProvider.cs
@@ -11,13 +11,15 @@ namespace Builder.Console
     {
         public BuilderServiceProvider()
         {
+            Options.EnableAutoVerification = false;
+            Options.SuppressLifestyleMismatchVerification = true;
             Options.AllowOverridingRegistrations = true;
             this.RegisterBuilder();
             RegisterSingleton<IConfiguration, BuilderConfiguration>();
-            RegisterSingleton<ILogger>(new LoggerConfiguration().WriteTo.Trace().CreateLogger());
+            RegisterSingleton<ILogger>(() => new LoggerConfiguration().WriteTo.Trace().CreateLogger());
         }
 
-        public void RegisterService(Type serviceType, object instance) => RegisterSingleton(serviceType, instance);
+        public void RegisterService(Type serviceType, object instance) => RegisterSingleton(serviceType, () => instance);
 
         public void RegisterService(Type serviceType, Func<object> instanceFactory) => RegisterSingleton(serviceType, instanceFactory);
     }

--- a/src/Take.Blip.Builder.UnitTests/Actions/ActionConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Actions/ActionConditionsTests.cs
@@ -22,7 +22,7 @@ namespace Take.Blip.Builder.UnitTests.Actions
         public override Container CreateContainer()
         {
             var container = base.CreateContainer();
-            container.RegisterSingleton(ActionProvider);
+            container.RegisterSingleton(() => ActionProvider);
             return container;
         }
 

--- a/src/Take.Blip.Builder.UnitTests/ExtensionContextTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/ExtensionContextTests.cs
@@ -33,14 +33,17 @@ namespace Take.Blip.Builder.UnitTests
         protected override ContextBase GetTarget()
         {
             var container = new Container();
+
+            container.Options.EnableAutoVerification = false;
+            container.Options.SuppressLifestyleMismatchVerification = true;
             container.Options.AllowOverridingRegistrations = true;
             container.RegisterBuilder();
-            container.RegisterSingleton(ContactExtension);
-            container.RegisterSingleton(HelpDeskExtension);
-            container.RegisterSingleton(TunnelExtension);
-            container.RegisterSingleton(ContextExtension);
-            container.RegisterSingleton(Sender);
-            container.RegisterSingleton(Application);
+            container.RegisterSingleton(() => ContactExtension);
+            container.RegisterSingleton(() => HelpDeskExtension);
+            container.RegisterSingleton(() => TunnelExtension);
+            container.RegisterSingleton(() => ContextExtension);
+            container.RegisterSingleton(() => Sender);
+            container.RegisterSingleton(() => Application);
 
             return new ExtensionContext(
                 User,

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -428,7 +428,7 @@ namespace Take.Blip.Builder.UnitTests
             var target = GetTarget(container =>
             {
                 container.RegisterSingleton<IContextProvider, ContextProvider>();
-                container.RegisterSingleton<IServiceProvider>(container);
+                container.RegisterSingleton<IServiceProvider>(() => container);
             });
 
             // Act

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTestsBase.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTestsBase.cs
@@ -120,23 +120,25 @@ namespace Take.Blip.Builder.UnitTests
         {
             var container = new Container();
 
+            container.Options.EnableAutoVerification = false;
+            container.Options.SuppressLifestyleMismatchVerification = true;
             container.Options.AllowOverridingRegistrations = true;
             container.RegisterBuilder();
-            container.RegisterSingleton(Application);
-            container.RegisterSingleton(SchedulerExtension);
-            container.RegisterSingleton(BucketExtension);
-            container.RegisterSingleton(ArtificialIntelligenceExtension);
-            container.RegisterSingleton(EventTrackExtension);
-            container.RegisterSingleton(BroadcastExtension);
-            container.RegisterSingleton(ContactExtension);
-            container.RegisterSingleton(HelpDeskExtension);
-            container.RegisterSingleton(TunnelExtension);
-            container.RegisterSingleton(ContextProvider);
-            container.RegisterSingleton(Sender);
-            container.RegisterSingleton(StateManager);
-            container.RegisterSingleton(Logger);
-            container.RegisterSingleton(TraceProcessor);
-            container.RegisterSingleton(UserOwnerResolver);
+            container.RegisterSingleton(() => Application);
+            container.RegisterSingleton(() => SchedulerExtension);
+            container.RegisterSingleton(() => BucketExtension);
+            container.RegisterSingleton(() => ArtificialIntelligenceExtension);
+            container.RegisterSingleton(() => EventTrackExtension);
+            container.RegisterSingleton(() => BroadcastExtension);
+            container.RegisterSingleton(() => ContactExtension);
+            container.RegisterSingleton(() => HelpDeskExtension);
+            container.RegisterSingleton(() => TunnelExtension);
+            container.RegisterSingleton(() => ContextProvider);
+            container.RegisterSingleton(() => Sender);
+            container.RegisterSingleton(() => StateManager);
+            container.RegisterSingleton(() => Logger);
+            container.RegisterSingleton(() => TraceProcessor);
+            container.RegisterSingleton(() => UserOwnerResolver);
 
             return container;
         }

--- a/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
+++ b/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
@@ -65,7 +65,7 @@ namespace Take.Blip.Builder.Hosting
         private static Container RegisterBuilderActions(this Container container)
         {
             container.RegisterSingleton<IActionProvider, ActionProvider>();
-            container.RegisterCollection<IAction>(
+            container.Collection.Register<IAction>(
                 new[]
                 {
                     typeof(ExecuteScriptAction),
@@ -129,7 +129,7 @@ namespace Take.Blip.Builder.Hosting
 
         private static Container RegisterBuilderVariables(this Container container)
         {
-            container.RegisterCollection<IVariableProvider>(
+            container.Collection.Register<IVariableProvider>(
                 new[]
                 {
                     typeof(ApplicationVariableProvider),
@@ -157,7 +157,7 @@ namespace Take.Blip.Builder.Hosting
                 });
             container.RegisterSingleton<IEnvelopeSerializer, EnvelopeSerializer>();
             container.RegisterSingleton<IDocumentSerializer, DocumentSerializer>();
-            container.RegisterSingleton<ILogger>(LoggerProvider.Logger);
+            container.RegisterSingleton<ILogger>(() => LoggerProvider.Logger);
 
             return container;
         }

--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="3.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />

--- a/src/Take.Blip.Client.Console/ConsoleRunner.cs
+++ b/src/Take.Blip.Client.Console/ConsoleRunner.cs
@@ -134,12 +134,12 @@ namespace Take.Blip.Client.Console
             return applicationJsonPath;
         }
 
-        internal static Task<IStoppable> StartAsync(string applicationFileName, CancellationToken cancellationToken)
+        internal static async Task<IStoppable> StartAsync(string applicationFileName, CancellationToken cancellationToken)
         {
             var application = Application.ParseFromJsonFile(applicationFileName);
             var workingDir = Path.GetDirectoryName(applicationFileName);
             if (string.IsNullOrWhiteSpace(workingDir)) workingDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-            return Bootstrapper.StartAsync(cancellationToken, application, typeResolver: new TypeResolver(workingDir));
+            return await Bootstrapper.StartAsync(cancellationToken, application, typeResolver: new TypeResolver(workingDir));
         }
 
         private static void WriteLine(string value = "", ConsoleColor color = ConsoleColor.White)


### PR DESCRIPTION
Our usage of an old SimpleInjector version is blocking the development of a new feature in our team. Thus, we are updating everywhere necessary.

As Builder is used internally by us (namely in TemplateHosting), there are a few tests there not passing because of the library version mismatch (both TemplateHosting and Take.Blip.Builder depend on SimpleInjector).

By the way, I've managed to make these unit tests pass quite easily (and probably the acceptance tests from TemplateHosting will pass as well), even though I still hadn't finished the implementation (it still had bugs). Thus, I also suggest the team responsible to take a look at the possibility of expanding the test suite.

What I'm most worried about with this change is knowing how will it impact our clients. 

One obvious impact is the update to SimpleInjector itself. Just like it happened with us, it may happen that our clients also use SimpleInjector in their projects and that will impact them. However, I think this is more on the light side, as updating dependencies is just a natural part of software development; We just need to make it clear in the release notes (I'm guessing there are release notes).

More subtle impacts could come in the form of dependencies that are now resolved or disposed differently or stuff like that. Is there an easy way we can test for this? Maybe dogfood with our internal clients?