### PR TITLE
Added context parameter to flowManager

### DIFF
--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -81,7 +81,12 @@ namespace Take.Blip.Builder
             _applicationNode = application.Node;
         }
 
-        public async Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken, IContext messageContext = null)
+        public async Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken)
+        {
+            await ProcessInputAsync(message, flow, null, cancellationToken);
+        }
+
+        public async Task ProcessInputAsync(Message message, Flow flow, IContext messageContext, CancellationToken cancellationToken)
         {
             if (message == null)
             {

--- a/src/Take.Blip.Builder/IFlowManager.cs
+++ b/src/Take.Blip.Builder/IFlowManager.cs
@@ -19,7 +19,7 @@ namespace Take.Blip.Builder
         /// <param name="cancellationToken">The operation cancellation token.</param>
         /// <param name="messageContext">Context from Message Receiver. Its not mandatory.</param>
         /// <returns></returns>
-        Task ProcessInputAsync(Message message, Flow flow, IContext messageContext = null, CancellationToken cancellationToken);
+        Task ProcessInputAsync(Message message, Flow flow, IContext messageContext, CancellationToken cancellationToken);
         Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/IFlowManager.cs
+++ b/src/Take.Blip.Builder/IFlowManager.cs
@@ -19,6 +19,7 @@ namespace Take.Blip.Builder
         /// <param name="cancellationToken">The operation cancellation token.</param>
         /// <param name="messageContext">Context from Message Receiver. Its not mandatory.</param>
         /// <returns></returns>
-        Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken, IContext messageContext = null);
+        Task ProcessInputAsync(Message message, Flow flow, IContext messageContext = null, CancellationToken cancellationToken);
+        Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/IFlowManager.cs
+++ b/src/Take.Blip.Builder/IFlowManager.cs
@@ -17,8 +17,8 @@ namespace Take.Blip.Builder
         /// <param name="message">The input message.</param>
         /// <param name="flow">The builder flow.</param>
         /// <param name="cancellationToken">The operation cancellation token.</param>
+        /// <param name="messageContext">Context from Message Receiver. Its not mandatory.</param>
         /// <returns></returns>
-
-        Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken);
+        Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken, IContext messageContext = null);
     }
 }


### PR DESCRIPTION
FlowManager now has a non mandatory parameter: messageContext, that allows the context beeing passed from MessageReceiver to save memory.