### PR TITLE
Fix error processing user inactive message.

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/InputExpirationHandlerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/InputExpirationHandlerTests.cs
@@ -68,7 +68,7 @@ namespace Take.Blip.Builder.UnitTests
             Message.Content = messageContent;
 
             // Act
-            var returnMessage = InputHandler.ValidateMessage(Message);
+            var (_, returnMessage) = InputHandler.ValidateMessage(Message);
 
             // Assert
             Assert.True(returnMessage.Metadata.ContainsKey(TraceSettings.BUILDER_TRACE_TARGET));

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -14,7 +14,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Take.Blip.Builder.Actions;
-using Take.Blip.Builder.Actions.Redirect;
 using Take.Blip.Builder.Diagnostics;
 using Take.Blip.Builder.Hosting;
 using Take.Blip.Builder.Models;
@@ -103,7 +102,15 @@ namespace Take.Blip.Builder
                 throw new ArgumentNullException(nameof(flow));
             }
 
-            message = _inputExpirationHandler.ValidateMessage(message);
+            var (messageHasChanged, newMessage) = _inputExpirationHandler.ValidateMessage(message);
+
+            // If the message has changedm the old context can't be used because it has the old message.
+            // Setting it to null will force a new context to be created later with the new message.
+            if (messageHasChanged)
+            {
+                messageContext = null;
+                message = newMessage;
+            }
 
             flow.Validate();
 

--- a/src/Take.Blip.Builder/IInputExpirationHandler.cs
+++ b/src/Take.Blip.Builder/IInputExpirationHandler.cs
@@ -1,15 +1,15 @@
-﻿using System.Threading;
+﻿using Lime.Protocol;
+using System.Threading;
 using System.Threading.Tasks;
-using Lime.Protocol;
 using Take.Blip.Builder.Models;
 
 namespace Take.Blip.Builder
 {
     public interface IInputExpirationHandler
     {
-        Message ValidateMessage(Message message);
+        (bool, Message) ValidateMessage(Message message);
         bool IsValidateState(State state, Message message);
         Task OnFlowPreProcessingAsync(State state, Message message, Node from, CancellationToken cancellationToken);
-        Task OnFlowProcessedAsync(State state, Message message, Node from,  CancellationToken cancellationToken);
+        Task OnFlowProcessedAsync(State state, Message message, Node from, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/InputExpirationHandler.cs
+++ b/src/Take.Blip.Builder/InputExpirationHandler.cs
@@ -3,7 +3,6 @@ using Lime.Protocol;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Take.Blip.Builder.Diagnostics;
@@ -92,7 +91,7 @@ namespace Take.Blip.Builder
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        public Message ValidateMessage(Message message)
+        public (bool, Message) ValidateMessage(Message message)
         {
             if (message.Content is InputExpiration inputExpiration)
             {
@@ -110,16 +109,18 @@ namespace Take.Blip.Builder
                 messageMetadata.Add(STATE_ID, inputExpiration.StateId);
                 messageMetadata.Add(IDENTITY, inputExpiration.Identity);
 
-                return new Message(message.Id)
+                message = new Message(message.Id)
                 {
                     To = message.To,
                     From = inputExpiration.Identity.ToNode(),
                     Content = _emptyContent,
                     Metadata = messageMetadata
                 };
+
+                return (true, message);
             }
 
-            return message;
+            return (false, message);
         }
 
         private bool IsMessageFromExpiration(Message message)


### PR DESCRIPTION
A recent changed made is passing the context to the SDK when processing
the input so it can be reused.

When a user inactive message is processed,
a new input message is created with an empty text and this new message
should be processed instead.

This changes fixes this by setting the context passed as parameter to
null when a user inactive message arrives so a new context will be
created in this case with the new message.