### PR TITLE
#308047: Changed the rule to composing mutex key to block simultaneous message

### DIFF
--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -45,6 +45,8 @@ namespace Take.Blip.Builder
         private readonly Node _applicationNode;
 
         private const string END_SUBFLOW_STATE_ID = "end";
+        private const string TUNNEL_OWNER_METADATA = "#tunnel.owner";
+        private const string TUNNEL_ORIGINATOR_METADATA = "#tunnel.originator";
 
         public FlowManager(
             IConfiguration configuration,
@@ -157,7 +159,9 @@ namespace Take.Blip.Builder
                 using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
                 {
                     // Synchronize to avoid concurrency issues on multiple running instances
-                    var handle = await _namedSemaphore.WaitAsync($"{flow.Id}:{userIdentity}", _configuration.InputProcessingTimeout, linkedCts.Token);
+                    // If the flow is contained in another flow, such as a subflow or a bot running on a router, the mutext key must consider the parent flow id. 
+                    var mutexKey = DefineMutexKey(message, flow, userIdentity);
+                    var handle = await _namedSemaphore.WaitAsync(mutexKey, _configuration.InputProcessingTimeout, linkedCts.Token);
                     try
                     {
                         // Create the input evaluator
@@ -539,6 +543,26 @@ namespace Take.Blip.Builder
             }
 
             return state;
+        }
+
+        private string DefineMutexKey(Message message, Flow flow, Identity userIdentity)
+        {
+            string parent = flow.Id;
+            string identity = userIdentity.ToString();
+
+            if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
+            {
+                //when the message is traveling in the context of a router, we must consider the key as the router identifier and the tunnel originator
+                message.Metadata.TryGetValue(TUNNEL_OWNER_METADATA, out parent);
+                message.Metadata.TryGetValue(TUNNEL_ORIGINATOR_METADATA, out identity);
+            }
+            else if (!flow.ParentId.IsNullOrEmpty())
+            {
+                //when the message is traveling in the context of subflow, we must consider the key as the parent flow
+                parent = flow.ParentId;
+            }
+
+            return $"{parent}:{identity}";
         }
     }
 }

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -159,7 +159,7 @@ namespace Take.Blip.Builder
                 using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
                 {
                     // Synchronize to avoid concurrency issues on multiple running instances
-                    // If the flow is contained in another flow, such as a subflow or a bot running on a router, the mutext key must consider the parent flow id. 
+                    // If the flow is contained in another flow, such as a subflow or a bot running on a router, the mutex key must consider the parent flow id. 
                     var mutexKey = DefineMutexKey(message, flow, userIdentity);
                     var handle = await _namedSemaphore.WaitAsync(mutexKey, _configuration.InputProcessingTimeout, linkedCts.Token);
                     try
@@ -547,8 +547,8 @@ namespace Take.Blip.Builder
 
         private string DefineMutexKey(Message message, Flow flow, Identity userIdentity)
         {
-            string parent = flow.Id;
-            string identity = userIdentity.ToString();
+            var parent = flow.Id;
+            var identity = userIdentity.ToString();
 
             if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
             {

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -550,7 +550,7 @@ namespace Take.Blip.Builder
             var parent = flow.Id;
             var identity = userIdentity.ToString();
 
-            if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
+            if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA) && message.Metadata.ContainsKey(TUNNEL_ORIGINATOR_METADATA))
             {
                 //when the message is traveling in the context of a router, we must consider the key as the router identifier and the tunnel originator
                 message.Metadata.TryGetValue(TUNNEL_OWNER_METADATA, out parent);

--- a/src/Take.Blip.Builder/Models/Flow.cs
+++ b/src/Take.Blip.Builder/Models/Flow.cs
@@ -45,6 +45,11 @@ namespace Take.Blip.Builder.Models
         public Dictionary<string, string> Configuration { get; set; }
 
         /// <summary>
+        /// The identifier of the parent flow.
+        /// </summary>
+        public string ParentId { get; set; }
+
+        /// <summary>
         /// Provides a view over the 'builder:' <see cref="Configuration"/> keys.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
Changed the rule to composing mutex key to block simultaneous message in subflow or router context