### PR TITLE
Changed the rule to composing mutex key to block simultaneous message

### DIFF
--- a/src/Take.Blip.Builder/BasicFlowSemaphore.cs
+++ b/src/Take.Blip.Builder/BasicFlowSemaphore.cs
@@ -1,0 +1,26 @@
+﻿using Lime.Protocol;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Take.Blip.Builder.Models;
+using Take.Blip.Builder.Storage;
+
+namespace Take.Blip.Builder
+{
+    class BasicFlowSemaphore: IFlowSemaphore
+    {
+        private readonly INamedSemaphore _namedSemaphore;
+
+        public BasicFlowSemaphore(
+            INamedSemaphore namedSemaphore
+            )
+        {
+            _namedSemaphore = namedSemaphore;
+        }
+
+        public Task<IAsyncDisposable> WaitAsync(Flow flow, Message message, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return _namedSemaphore.WaitAsync($"{flow.Id}:{userIdentity}", timeout, cancellationToken);
+        }
+    }
+}

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -45,6 +45,8 @@ namespace Take.Blip.Builder
         private readonly Node _applicationNode;
 
         private const string END_SUBFLOW_STATE_ID = "end";
+        private const string TUNNEL_OWNER_METADATA = "#tunnel.owner";
+        private const string TUNNEL_ORIGINATOR_METADATA = "#tunnel.originator";
 
         public FlowManager(
             IConfiguration configuration,
@@ -157,7 +159,7 @@ namespace Take.Blip.Builder
                 using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
                 {
                     // Synchronize to avoid concurrency issues on multiple running instances
-                    var handle = await _namedSemaphore.WaitAsync($"{flow.Id}:{userIdentity}", _configuration.InputProcessingTimeout, linkedCts.Token);
+                    var handle = await _namedSemaphore.WaitAsync(DefineMutexKey(message, flow, userIdentity), _configuration.InputProcessingTimeout, linkedCts.Token);
                     try
                     {
                         // Create the input evaluator
@@ -543,6 +545,26 @@ namespace Take.Blip.Builder
             }
 
             return state;
+        }
+
+        private string DefineMutexKey(Message message, Flow flow, Identity userIdentity)
+        {
+            string parent = flow.Id;
+            string identity = userIdentity.ToString();
+
+            if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
+            {
+                //when the message is traveling in the context of a router, we must consider the key as the router identifier and the tunnel originator
+                message.Metadata.TryGetValue(TUNNEL_OWNER_METADATA, out parent);
+                message.Metadata.TryGetValue(TUNNEL_ORIGINATOR_METADATA, out identity);
+            }
+            else if (!flow.ParentId.IsNullOrEmpty())
+            {
+                //when the message is traveling in the context of subflow, we must consider the key as the parent flow
+                parent = flow.ParentId;
+            }
+
+            return $"{parent}:{identity}";
         }
     }
 }

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -549,8 +549,8 @@ namespace Take.Blip.Builder
 
         private string DefineMutexKey(Message message, Flow flow, Identity userIdentity)
         {
-            string parent = flow.Id;
-            string identity = userIdentity.ToString();
+            var parent = flow.Id;
+            var identity = userIdentity.ToString();
 
             if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
             {

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -552,11 +552,13 @@ namespace Take.Blip.Builder
             var parent = flow.Id;
             var identity = userIdentity.ToString();
 
-            if (message.Metadata != null && message.Metadata.ContainsKey(TUNNEL_OWNER_METADATA))
+            if (message.Metadata != null
+                && message.Metadata.TryGetValue(TUNNEL_OWNER_METADATA, out var parentTunnel)
+                && message.Metadata.TryGetValue(TUNNEL_ORIGINATOR_METADATA, out var identityTunnel))
             {
                 //when the message is traveling in the context of a router, we must consider the key as the router identifier and the tunnel originator
-                message.Metadata.TryGetValue(TUNNEL_OWNER_METADATA, out parent);
-                message.Metadata.TryGetValue(TUNNEL_ORIGINATOR_METADATA, out identity);
+                parent = parentTunnel;
+                identity = identityTunnel;
             }
             else if (!flow.ParentId.IsNullOrEmpty())
             {

--- a/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
+++ b/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
@@ -109,6 +109,7 @@ namespace Take.Blip.Builder.Hosting
         private static Container RegisterBuilderStorage(this Container container)
         {
             container.RegisterSingleton<INamedSemaphore, MemoryNamedSemaphore>();
+            container.RegisterSingleton<IFlowSemaphore, BasicFlowSemaphore>();
             container.RegisterSingleton<ISerializer<StorageDocument>, JsonSerializer<StorageDocument>>();
             container.RegisterSingleton<ISerializer<Contact>, JsonSerializer<Contact>>();
 

--- a/src/Take.Blip.Builder/IFlowSemaphore.cs
+++ b/src/Take.Blip.Builder/IFlowSemaphore.cs
@@ -1,0 +1,26 @@
+﻿using Lime.Protocol;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Take.Blip.Builder.Models;
+
+namespace Take.Blip.Builder
+{
+
+    /// <summary>
+    /// Defines a flow semaphore service, used to block the processing of two messages from the same contact and bot
+    /// </summary>
+    public interface IFlowSemaphore
+    {
+        /// <summary>
+        /// Do semaphore lock to block the processing of two messages from the same contact and bot
+        /// </summary>
+        /// <param name="flow">Flow</param>
+        /// <param name="message">Message</param>
+        /// <param name="userIdentity">User identity</param>
+        /// <param name="timeout">Timeout</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task<IAsyncDisposable> WaitAsync(Flow flow, Message message, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken);
+    }
+}

--- a/src/Take.Blip.Builder/Models/Flow.cs
+++ b/src/Take.Blip.Builder/Models/Flow.cs
@@ -45,6 +45,11 @@ namespace Take.Blip.Builder.Models
         public Dictionary<string, string> Configuration { get; set; }
 
         /// <summary>
+        /// The identifier of the parent flow.
+        /// </summary>
+        public string ParentId { get; set; }
+
+        /// <summary>
         /// Provides a view over the 'builder:' <see cref="Configuration"/> keys.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
Changed the rule to composing mutex key to block simultaneous message processing.
The way it was before, it's was been possible to process two message simultaneously to the same contact and bot when existed subflows or router in the flow.