### PR TITLE
Feature/Review of message processing failure logs

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -328,6 +328,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("TrackEvent");
         }
 
         [Fact]
@@ -364,6 +365,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("ProcessHttp");
         }
 
         [Fact]
@@ -399,6 +401,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("Redirect");
         }
 
         [Fact]
@@ -431,6 +434,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("output condition to state");
         }
 
         [Fact]
@@ -468,6 +472,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("ExecuteScript");
         }
 
         [Fact]
@@ -603,6 +608,7 @@ namespace Take.Blip.Builder.UnitTests
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
             exception.Message.ShouldContain("[FlowConstruction]");
+            exception.Message.ShouldContain("Max state transitions");
         }
 
         [Fact]

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -327,7 +327,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe("[FlowConstruction] The processing of the action 'TrackEvent' has failed");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]
@@ -363,7 +363,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe("[FlowConstruction] The processing of the action 'ProcessHttp' has failed");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe("[FlowConstruction] The processing of the action 'Redirect' has failed");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]
@@ -430,7 +430,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe($"[FlowConstruction] Failed to process output condition to state '{stateIdVariable}'");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]
@@ -467,7 +467,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe("[FlowConstruction] The processing of the action 'ExecuteScript' has failed");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]
@@ -602,7 +602,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Act
             var exception = await target.ProcessInputAsync(Message, flow, CancellationToken).ShouldThrowAsync<FlowConstructionException>();
-            exception.Message.ShouldBe("[FlowConstruction] Max state transitions of 10 was reached");
+            exception.Message.ShouldContain("[FlowConstruction]");
         }
 
         [Fact]

--- a/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Jint.Runtime;
+
+namespace Take.Blip.Builder
+{
+    /// <summary>
+    /// Defines a builder exception analyze service.
+    /// </summary>
+    public class AnalyzeBuilderExceptions : IAnalyzeBuilderExceptions
+    {
+        private List<Func<Exception, bool>> _validations;
+        private const string FLOW_CONSTRUCTION_TAG = "[FlowConstruction]";
+
+        /// <inheritdoc />
+        public AnalyzeBuilderExceptions()
+        {
+            _validations = new List<Func<Exception, bool>>()
+            {
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ArgumentException,
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ValidationException,
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is JavaScriptException,
+                ex => ex is OutputProcessingException
+            };
+        }
+
+        /// <inheritdoc />
+        public Exception VerifyFlowConstructionException(Exception ex)
+        {
+            foreach (var validation in _validations)
+            {
+                if (validation(ex))
+                {
+                    return new FlowConstructionException(CreateFlowConstructionExceptionMessage(ex.Message), ex);
+                }
+            }
+
+            return ex;
+        }
+
+        /// <inheritdoc />
+        public string CreateFlowConstructionExceptionMessage(string message)
+        {
+            return $"{FLOW_CONSTRUCTION_TAG} {message}";        
+        }
+    }
+}

--- a/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
@@ -11,7 +11,6 @@ namespace Take.Blip.Builder
     public class AnalyzeBuilderExceptions : IAnalyzeBuilderExceptions
     {
         private List<Func<Exception, bool>> _validations;
-        private const string FLOW_CONSTRUCTION_TAG = "[FlowConstruction]";
 
         /// <inheritdoc />
         public AnalyzeBuilderExceptions()
@@ -32,17 +31,11 @@ namespace Take.Blip.Builder
             {
                 if (validation(ex))
                 {
-                    return new FlowConstructionException(CreateFlowConstructionExceptionMessage(ex.Message), ex);
+                    return new FlowConstructionException(ex.Message, ex);
                 }
             }
 
             return ex;
-        }
-
-        /// <inheritdoc />
-        public string CreateFlowConstructionExceptionMessage(string message)
-        {
-            return $"{FLOW_CONSTRUCTION_TAG} {message}";        
         }
     }
 }

--- a/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
@@ -17,9 +17,9 @@ namespace Take.Blip.Builder
         {
             _validations = new List<Func<Exception, bool>>()
             {
-                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ArgumentException,
-                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ValidationException,
-                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is JavaScriptException,
+                ex => ex is ActionProcessingException && ex?.InnerException is ArgumentException,
+                ex => ex is ActionProcessingException && ex?.InnerException is ValidationException,
+                ex => ex is ActionProcessingException && ex?.InnerException is JavaScriptException,
                 ex => ex is OutputProcessingException
             };
         }

--- a/src/Take.Blip.Builder/FlowConstructionException.cs
+++ b/src/Take.Blip.Builder/FlowConstructionException.cs
@@ -7,14 +7,21 @@ namespace Take.Blip.Builder
     /// </summary>
     public class FlowConstructionException : BuilderException
     {
+        private const string FLOW_CONSTRUCTION_TAG = "[FlowConstruction]";
+
         /// <inheritdoc />
-        public FlowConstructionException(string message) : base(message)
+        public FlowConstructionException(string message) : base(ModifyMessage(message))
         {
         }
 
         /// <inheritdoc />
-        public FlowConstructionException(string message, Exception innerException) : base(message, innerException)
+        public FlowConstructionException(string message, Exception innerException) : base(ModifyMessage(message), innerException)
         {
+        }
+
+        private static string ModifyMessage(string message)
+        {
+            return $"{FLOW_CONSTRUCTION_TAG} {message}";
         }
     }
 }

--- a/src/Take.Blip.Builder/FlowConstructionException.cs
+++ b/src/Take.Blip.Builder/FlowConstructionException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Take.Blip.Builder
+{
+    /// <summary>
+    /// Defines an exception thrown by the botmaker's flow construction.
+    /// </summary>
+    public class FlowConstructionException : BuilderException
+    {
+        /// <inheritdoc />
+        public FlowConstructionException(string message) : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public FlowConstructionException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -297,7 +297,7 @@ namespace Take.Blip.Builder
                                 // Check if the state transition limit has reached (to avoid loops in the flow)
                                 if (transitions++ >= _configuration.MaxTransitionsByInput)
                                 {
-                                    throw new FlowConstructionException(_analyzeBuilderExceptions.CreateFlowConstructionExceptionMessage($"Max state transitions of {_configuration.MaxTransitionsByInput} was reached"));
+                                    throw new FlowConstructionException($"Max state transitions of {_configuration.MaxTransitionsByInput} was reached");
                                 }
                             }
                             catch (Exception ex)

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -94,11 +94,13 @@ namespace Take.Blip.Builder
 
         private void InitializeValidations()
         {
-            _validations = new List<Func<Exception, bool>>();
-            _validations.Add(ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ArgumentException);
-            _validations.Add(ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ValidationException);
-            _validations.Add(ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is JavaScriptException);
-            _validations.Add(ex => ex is OutputProcessingException);
+            _validations = new List<Func<Exception, bool>>()
+            {
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ArgumentException,
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is ValidationException,
+                ex => ex is ActionProcessingException && ex.InnerException != null && ex.InnerException is JavaScriptException,
+                ex => ex is OutputProcessingException
+            };
         }
 
         public async Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken)
@@ -305,7 +307,7 @@ namespace Take.Blip.Builder
                                 // Check if the state transition limit has reached (to avoid loops in the flow)
                                 if (transitions++ >= _configuration.MaxTransitionsByInput)
                                 {
-                                    throw new FlowConstructionException($"Max state transitions of {_configuration.MaxTransitionsByInput} was reached");
+                                    throw new FlowConstructionException($"[FlowConstruction] Max state transitions of {_configuration.MaxTransitionsByInput} was reached");
                                 }
                             }
                             catch (Exception ex)

--- a/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
+++ b/src/Take.Blip.Builder/Hosting/ContainerExtensions.cs
@@ -122,6 +122,7 @@ namespace Take.Blip.Builder.Hosting
         {
             container.RegisterSingleton<IVariableReplacer, VariableReplacer>();
             container.RegisterSingleton<IHttpClient, HttpClientWrapper>();
+            container.RegisterSingleton<IAnalyzeBuilderExceptions, AnalyzeBuilderExceptions>();
 
             return container;
         }

--- a/src/Take.Blip.Builder/IAnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/IAnalyzeBuilderExceptions.cs
@@ -13,12 +13,5 @@ namespace Take.Blip.Builder
         /// <param name="ex">An exception that occurred during the flow.</param>
         /// <returns></returns>
         Exception VerifyFlowConstructionException(Exception ex);
-
-        /// <summary>
-        /// Process a flow construction exception message.
-        /// </summary>
-        /// <param name="message">The error message.</param>
-        /// <returns></returns>
-        string CreateFlowConstructionExceptionMessage(string message);
     }
 }

--- a/src/Take.Blip.Builder/IAnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/IAnalyzeBuilderExceptions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Take.Blip.Builder
+{
+    /// <summary>
+    /// Defines a builder exception analyze service.
+    /// </summary>
+    public interface IAnalyzeBuilderExceptions
+    {
+        /// <summary>
+        /// Process an exception and determine if is Flow Construction Exception or not.
+        /// </summary>
+        /// <param name="ex">An exception that occurred during the flow.</param>
+        /// <returns></returns>
+        Exception VerifyFlowConstructionException(Exception ex);
+
+        /// <summary>
+        /// Process a flow construction exception message.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <returns></returns>
+        string CreateFlowConstructionExceptionMessage(string message);
+    }
+}

--- a/src/Take.Blip.Client/BlipChannelListener.cs
+++ b/src/Take.Blip.Client/BlipChannelListener.cs
@@ -327,7 +327,13 @@ namespace Take.Blip.Client
             using (LogContext.PushProperty(nameof(Envelope.From), envelope.From))
             using (LogContext.PushProperty(nameof(Envelope.To), envelope.To))
             {
-                _logger.Error(ex, "Error processing the received envelope: {Message}", ex.Message);
+                if(ex.GetType().Name == "FlowConstructionException")
+                {
+                    _logger.Warning(ex, "{Message}", ex.Message);
+                } else
+                {
+                    _logger.Error(ex, "Error processing the received envelope: {Message}", ex.Message);
+                }
             }
         }
 

--- a/src/Take.Blip.Client/BlipChannelListener.cs
+++ b/src/Take.Blip.Client/BlipChannelListener.cs
@@ -31,6 +31,7 @@ namespace Take.Blip.Client
 
         private CancellationTokenSource _cts;
         private readonly object _syncRoot = new object();
+        private const string FLOW_CONSTRUCTION_EXCEPTION = "FlowConstructionException";
 
         public BlipChannelListener(ISender sender, bool autoNotify, ILogger logger = null)
         {
@@ -327,9 +328,9 @@ namespace Take.Blip.Client
             using (LogContext.PushProperty(nameof(Envelope.From), envelope.From))
             using (LogContext.PushProperty(nameof(Envelope.To), envelope.To))
             {
-                if(ex.GetType().Name == "FlowConstructionException")
+                if(ex.GetType().Name == FLOW_CONSTRUCTION_EXCEPTION)
                 {
-                    _logger.Warning(ex, "{Message}", ex.Message);
+                    _logger.Warning(ex, "Error processing the received envelope: {Message}", ex.Message);
                 } else
                 {
                     _logger.Error(ex, "Error processing the received envelope: {Message}", ex.Message);

--- a/src/Take.Blip.Client/BlipChannelListener.cs
+++ b/src/Take.Blip.Client/BlipChannelListener.cs
@@ -32,6 +32,7 @@ namespace Take.Blip.Client
         private CancellationTokenSource _cts;
         private readonly object _syncRoot = new object();
         private const string FLOW_CONSTRUCTION_EXCEPTION = "FlowConstructionException";
+        private const string DEFAULT_ERROR_MESSAGE = "Error processing the received envelope:";
 
         public BlipChannelListener(ISender sender, bool autoNotify, ILogger logger = null)
         {
@@ -330,10 +331,10 @@ namespace Take.Blip.Client
             {
                 if(ex.GetType().Name == FLOW_CONSTRUCTION_EXCEPTION)
                 {
-                    _logger.Warning(ex, "Error processing the received envelope: {Message}", ex.Message);
+                    _logger.Warning(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
                 } else
                 {
-                    _logger.Error(ex, "Error processing the received envelope: {Message}", ex.Message);
+                    _logger.Error(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
                 }
             }
         }


### PR DESCRIPTION
The following logs changed from error to warning and became FlowConstructionException:
- The processing of the action 'TrackEvent' has failed
- The processing of the action 'ExecuteScript' has failed
- The processing of the action 'ProcessHttp' has failed
- Failed to process output condition to state '{invalid-state-id}'
- The processing of the action 'Redirect' has failed
- Max state transitions of 35 was reached