### PR TITLE
Feature/Updated Simple Injector and Added Max Thread Count Allowed Configuration

### DIFF
--- a/src/Samples/Builder.Console/Builder.Console.csproj
+++ b/src/Samples/Builder.Console/Builder.Console.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="Take.Elephant" Version="0.10.2" />

--- a/src/Take.Blip.Client/BlipChannelListener.cs
+++ b/src/Take.Blip.Client/BlipChannelListener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ namespace Take.Blip.Client
         private readonly ISender _sender;
         private readonly bool _autoNotify;
         private readonly ILogger _logger;
-
+        private readonly int _maxThreadCountAllowed;
         private readonly IChannelListener _channelListener;
         private readonly IList<ReceiverFactoryPredicate<Message>> _messageReceivers;
         private readonly IList<ReceiverFactoryPredicate<Notification>> _notificationReceivers;
@@ -32,12 +33,17 @@ namespace Take.Blip.Client
         private CancellationTokenSource _cts;
         private readonly object _syncRoot = new object();
 
-        public BlipChannelListener(ISender sender, bool autoNotify, ILogger logger = null)
+        public BlipChannelListener(
+            ISender sender, 
+            bool autoNotify, 
+            ILogger logger = null,
+            int maxThreadCountAllowed = 0
+        )
         {
             _sender = sender ?? throw new ArgumentNullException(nameof(sender));
             _autoNotify = autoNotify;
             _logger = logger ?? LoggerProvider.Logger;
-
+            _maxThreadCountAllowed = maxThreadCountAllowed;
             _messageReceivers = new List<ReceiverFactoryPredicate<Message>>(new[]
             {
                 new ReceiverFactoryPredicate<Message>(() => new UnsupportedMessageReceiver(), m => Task.FromResult(true), int.MaxValue)
@@ -307,6 +313,8 @@ namespace Take.Blip.Client
                 .OrderBy(r => r.Key)
                 .First(r => r.Any());
 
+            AssertMaxThreadCountAllowed();
+
             await Task.WhenAll(
                 receiverGroup.Select(r =>
                 {
@@ -318,6 +326,17 @@ namespace Take.Blip.Client
                 
                     return receiver.ReceiveAsync(envelope, cancellationToken);
                 }));
+        }
+
+        private void AssertMaxThreadCountAllowed()
+        {
+            if (
+                _maxThreadCountAllowed > 0 &&
+                Process.GetCurrentProcess().Threads.Count > _maxThreadCountAllowed
+                )
+            {
+                throw new InvalidOperationException($"Exceeded max thread count of Template Hosting ({_maxThreadCountAllowed})");
+            }
         }
 
         private void LogException<T>(T envelope, Exception ex) where T : Envelope


### PR DESCRIPTION
1. Updated simple injector to version 5.4.1
2. Added MaxThreadCountAllowed in BlipChannelListener constructor to create a circuit breaker regarding the number of threads in the process allowed to process new messages.