### PR TITLE
Removed unnecessary query to previous-stateId context variable

### DIFF
--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -188,7 +188,6 @@ namespace Take.Blip.Builder
 
                         // Try restore a stored state
                         var stateId = await _stateManager.GetStateIdAsync(context, linkedCts.Token);
-                        var previousState = await _stateManager.GetPreviousStateIdAsync(context, linkedCts.Token);
 
                         state = flow.States.FirstOrDefault(s => s.Id == stateId) ?? flow.States.Single(s => s.Root);
 


### PR DESCRIPTION
Removed unnecessary query to previous-stateId context variable