### PR TITLE
Fixed two errors to being considered FlowConstruction type errors on log

### DIFF
--- a/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
@@ -18,7 +18,6 @@ namespace Take.Blip.Builder
             _validations = new List<Func<Exception, bool>>()
             {
                 ex => ex is ActionProcessingException && ex?.InnerException is ArgumentException,
-                ex => ex is ActionProcessingException && ex?.InnerException is NullReferenceException,
                 ex => ex is ActionProcessingException && ex?.InnerException is ValidationException,
                 ex => ex is ActionProcessingException && ex?.InnerException is JavaScriptException,
                 ex => ex is OutputProcessingException

--- a/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
+++ b/src/Take.Blip.Builder/AnalyzeBuilderExceptions.cs
@@ -18,6 +18,7 @@ namespace Take.Blip.Builder
             _validations = new List<Func<Exception, bool>>()
             {
                 ex => ex is ActionProcessingException && ex?.InnerException is ArgumentException,
+                ex => ex is ActionProcessingException && ex?.InnerException is NullReferenceException,
                 ex => ex is ActionProcessingException && ex?.InnerException is ValidationException,
                 ex => ex is ActionProcessingException && ex?.InnerException is JavaScriptException,
                 ex => ex is OutputProcessingException

--- a/src/Take.Blip.Client/BlipChannelListener.cs
+++ b/src/Take.Blip.Client/BlipChannelListener.cs
@@ -348,12 +348,14 @@ namespace Take.Blip.Client
             using (LogContext.PushProperty(nameof(Envelope.From), envelope.From))
             using (LogContext.PushProperty(nameof(Envelope.To), envelope.To))
             {
-                if(ex.GetType().Name == FLOW_CONSTRUCTION_EXCEPTION)
+                switch (ex.GetType().Name)
                 {
-                    _logger.Warning(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
-                } else
-                {
-                    _logger.Error(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
+                    case FLOW_CONSTRUCTION_EXCEPTION:
+                        _logger.Warning(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
+                        break;
+                    default:
+                        _logger.Error(ex, DEFAULT_ERROR_MESSAGE + " {Message}", ex.Message);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Added a new validation in the AnalyzeBuilderException.cs file to cover errors that happen in the Iris project.