### PR TITLE
Chaging JObject to JRaw to improve memory usage

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/Diagnostics/FlowTraceTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Diagnostics/FlowTraceTests.cs
@@ -60,11 +60,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -141,11 +143,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -214,29 +218,35 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -249,11 +259,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         },
                         OutputActions = new[]
@@ -261,20 +273,24 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -349,29 +365,35 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -383,11 +405,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         },
                         OutputActions = new[]
@@ -395,20 +419,24 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             },
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -496,11 +524,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -577,11 +607,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pingMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pingMessageContent }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -601,11 +633,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -683,11 +717,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "x",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pingMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pingMessageContent }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -707,11 +743,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     }

--- a/src/Take.Blip.Builder.UnitTests/Diagnostics/TraceProcessorTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/Diagnostics/TraceProcessorTests.cs
@@ -58,11 +58,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                                 new ActionTrace
                                 {
                                     Type = "ProcessHttp",
-                                    ParsedSettings = new JObject
-                                    {
-                                        { "property1", "value1" },
-                                        { "property2", 2 }
-                                    },
+                                    ParsedSettings = new JRaw(
+                                        new JObject
+                                        {
+                                            { "property1", "value1" },
+                                            { "property2", 2 }
+                                        }
+                                    ),
                                     ElapsedMilliseconds = 150
                                 }
                             },
@@ -85,12 +87,14 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                                 new ActionTrace
                                 {
                                     Type = "SendMessage",
-                                    ParsedSettings = new JObject
-                                    {
-                                        { "to", "user@domain.com" },
-                                        { "type", "text/plain" },
-                                        { "content", "Hi there!" }
-                                    },
+                                    ParsedSettings = new JRaw(
+                                        new JObject
+                                        {
+                                            { "to", "user@domain.com" },
+                                            { "type", "text/plain" },
+                                            { "content", "Hi there!" }
+                                        }
+                                    ),
                                     ElapsedMilliseconds = 150
                                 }
                             }
@@ -145,11 +149,13 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                                 new ActionTrace
                                 {
                                     Type = "ProcessHttp",
-                                    ParsedSettings = new JObject
-                                    {
-                                        { "property1", "value1" },
-                                        { "property2", 2 }
-                                    },
+                                    ParsedSettings = new JRaw(
+                                        new JObject
+                                        {
+                                            { "property1", "value1" },
+                                            { "property2", 2 }
+                                        }
+                                    ),
                                     ElapsedMilliseconds = 150
                                 }
                             },
@@ -172,12 +178,14 @@ namespace Take.Blip.Builder.UnitTests.Diagnostics
                                 new ActionTrace
                                 {
                                     Type = "SendMessage",
-                                    ParsedSettings = new JObject
-                                    {
-                                        { "to", "user@domain.com" },
-                                        { "type", "text/plain" },
-                                        { "content", "Hi there!" }
-                                    },
+                                    ParsedSettings = new JRaw(
+                                        new JObject
+                                        {
+                                            { "to", "user@domain.com" },
+                                            { "type", "text/plain" },
+                                            { "content", "Hi there!" }
+                                        }
+                                    ),
                                     ElapsedMilliseconds = 150
                                 }
                             }

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -58,11 +58,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -128,11 +130,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -198,11 +202,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -264,11 +270,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -313,11 +321,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "TrackEvent",
-                                Settings = new JObject()
-                                {
-                                    {"category", "Variable doesn't exist"},
-                                    {"action", "{{variable.doesntExist}}"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "category", "Variable doesn't exist" },
+                                        { "action", "{{variable.doesntExist}}" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -350,11 +360,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "ProcessHttp",
-                                Settings = new JObject()
-                                {
-                                    {"method", "GET"},
-                                    {"uri", "{{variable.doesntExist}}"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "method", "GET" },
+                                        { "uri", "{{variable.doesntExist}}" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -387,10 +399,12 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "Redirect",
-                                Settings = new JObject()
-                                {
-                                    {"address", "{{variable.doesntExist}}"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "address", "{{variable.doesntExist}}" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -456,12 +470,14 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "ExecuteScript",
-                                Settings = new JObject()
-                                {
-                                    {"function", "run"},
-                                    {"source", "function run(inputVariable1, inputVariable2) {\n    let a = inputVariable1.doesntExist;\n    let b = inputVariable2.doesntExist;\n\n    return a * b;\n}"},
-                                    {"outputVariable", "invalidScript"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "function", "run" },
+                                        { "source", "function run(inputVariable1, inputVariable2) {\n    let a = inputVariable1.doesntExist;\n    let b = inputVariable2.doesntExist;\n\n    return a * b;\n}" },
+                                        { "outputVariable", "invalidScript" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -730,11 +746,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType },
-                                    {"content", "Hello, {{contact.name}}"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", "Hello, {{contact.name}}" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -827,11 +845,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -843,11 +863,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", poloMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", poloMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -899,7 +921,8 @@ namespace Take.Blip.Builder.UnitTests
                 .Returns(callInfo =>
                 {
                     var key = callInfo.ArgAt<string>(0);
-                    if (variables.TryGetValue(key, out var value)) return value;
+                    if (variables.TryGetValue(key, out var value))
+                        return value;
                     return null;
                 });
 
@@ -941,12 +964,14 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "ExecuteScript",
-                                Settings = new JObject()
-                                {
-                                    { "function", "run" },
-                                    { "source", "function run() { return true; }" }, // Satisfying Input condition above
-                                    { "outputVariable", "InputIsValid" }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "function", "run" },
+                                        { "source", "function run() { return true; }" }, // Satisfying Input condition above
+                                        { "outputVariable", "InputIsValid" }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -991,11 +1016,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", okMessageContent }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", okMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1007,11 +1034,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", nokMessageContent }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType},
+                                        { "content", nokMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1023,11 +1052,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", "failed to set variable" }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", "failed to set variable" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1077,7 +1108,8 @@ namespace Take.Blip.Builder.UnitTests
                 .Returns(callInfo =>
                 {
                     var key = callInfo.ArgAt<string>(0);
-                    if (variables.TryGetValue(key, out var value)) return value;
+                    if (variables.TryGetValue(key, out var value))
+                        return value;
                     return null;
                 });
 
@@ -1119,12 +1151,14 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "ExecuteScript",
-                                Settings = new JObject()
-                                {
-                                    { "function", "run" },
-                                    { "source", "function run(content) { return false; }" }, // Not satisfying Input condition above
-                                    { "outputVariable", "InputIsValid" }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "function", "run" },
+                                        { "source", "function run(content) { return false; }" }, // Not satisfying Input condition above
+                                        { "outputVariable", "InputIsValid" }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -1169,11 +1203,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", okMessageContent }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", okMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1185,11 +1221,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", nokMessageContent }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", nokMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1201,11 +1239,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", "failed to set variable" }
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", "failed to set variable" }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1314,11 +1354,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1330,11 +1372,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", poloMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", poloMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1419,11 +1463,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1435,11 +1481,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", "This is not supposed to be received..."}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", "This is not supposed to be received..." }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1538,11 +1586,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -1554,11 +1604,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", "This is not supposed to be received..."}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", "This is not supposed to be received..." }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1643,11 +1695,13 @@ namespace Take.Blip.Builder.UnitTests
                             {
                                 Type = "SendMessage",
                                 Timeout = timeout.TotalSeconds,
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1695,11 +1749,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1748,11 +1804,13 @@ namespace Take.Blip.Builder.UnitTests
                             {
                                 Type = "SendMessage",
                                 ContinueOnError = true,
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }

--- a/src/Take.Blip.Builder.UnitTests/InputValidations/InputValidationsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/InputValidations/InputValidationsTests.cs
@@ -62,11 +62,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -137,11 +139,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -211,11 +215,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -285,11 +291,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -365,11 +373,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -454,11 +464,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -547,11 +559,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -621,11 +635,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }

--- a/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OutputConditions/OutputConditionsTests.cs
@@ -67,11 +67,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -83,11 +85,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", poloMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", poloMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -166,11 +170,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", pongMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", pongMessageContent }
+                                    }
+                                )
                             }
                         }
                     },
@@ -182,11 +188,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", poloMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", poloMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -260,11 +268,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -336,11 +346,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", sentMessageType},
-                                    {"content", sentMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", sentMessageType },
+                                        { "content", sentMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -390,11 +402,13 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", sentMessageType},
-                                    {"content", sentMessageContent}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", sentMessageType },
+                                        { "content", sentMessageContent }
+                                    }
+                                )
                             }
                         }
                     }
@@ -842,7 +856,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Message.Content = new PlainText() { Text = "hello" };
 
             // Act
-            await Assert.ThrowsAsync<OutputProcessingException>(
+            await Assert.ThrowsAsync<FlowConstructionException>(
                 async () => await target.ProcessInputAsync(Message, flow, CancellationToken)
             );
 
@@ -868,7 +882,7 @@ namespace Take.Blip.Builder.UnitTests.OutputConditions
             Message.Content = new PlainText() { Text = "hello" };
 
             // Act
-            await Assert.ThrowsAsync<OutputProcessingException>(
+            await Assert.ThrowsAsync<FlowConstructionException>(
                 async () => await target.ProcessInputAsync(Message, flow, CancellationToken)
             );
 

--- a/src/Take.Blip.Builder.UnitTests/SubflowTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/SubflowTests.cs
@@ -287,11 +287,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContentSubflow}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContentSubflow }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -339,11 +341,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent}
-                                }
+                                Settings = new JRaw (
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent }
+                                    }
+                                )
                             }
                         },
                         Outputs = new[]
@@ -375,19 +379,23 @@ namespace Take.Blip.Builder.UnitTests
                         InputActions = new[] { 
                             new Action() {
                                 Type = "SetVariable",
-                                Settings = new JObject() {
-                                    {"variable", "testSetVariableInput"},
-                                    {"value", "testSetVariableInputValue"}
-                                }
+                                Settings = new JRaw(
+                                        new JObject() {
+                                        { "variable", "testSetVariableInput" },
+                                        { "value", "testSetVariableInputValue" }
+                                    }
+                                )
                             }
                         },
                         OutputActions = new[] {
                             new Action() {
                                 Type = "SetVariable",
-                                Settings = new JObject() {
-                                    {"variable", "testSetVariableOutput"},
-                                    {"value", "testSetVariableOutputValue"}
-                                }
+                                Settings = new JRaw(
+                                    new JObject() {
+                                        { "variable", "testSetVariableOutput" },
+                                        { "value", "testSetVariableOutputValue" }
+                                    }
+                                )
                             }
                         }
                     },
@@ -399,11 +407,13 @@ namespace Take.Blip.Builder.UnitTests
                             new Action
                             {
                                 Type = "SendMessage",
-                                Settings = new JObject()
-                                {
-                                    {"type", messageType},
-                                    {"content", messageContent2}
-                                }
+                                Settings = new JRaw(
+                                    new JObject()
+                                    {
+                                        { "type", messageType },
+                                        { "content", messageContent2 }
+                                    }
+                                )
                             }
                         }
                     }

--- a/src/Take.Blip.Builder/Diagnostics/ActionTrace.cs
+++ b/src/Take.Blip.Builder/Diagnostics/ActionTrace.cs
@@ -12,7 +12,7 @@ namespace Take.Blip.Builder.Diagnostics
         public string Type { get; set; }
 
         [DataMember(Name = "parsedSettings")]
-        public JObject ParsedSettings { get; set; }
+        public JRaw ParsedSettings { get; set; }
         
         [DataMember(Name = "continueOnError")]
         public bool ContinueOnError { get; set; }

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -521,7 +521,7 @@ namespace Take.Blip.Builder
 
                         if (actionTrace != null)
                         {
-                            actionTrace.ParsedSettings = jObjectSettings;
+                            actionTrace.ParsedSettings = new JRaw(stringifySetting);
                         }
 
                         using (LogContext.PushProperty(nameof(BuilderException.MessageId), lazyInput?.Message?.Id))

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -510,7 +510,7 @@ namespace Take.Blip.Builder
                 {
                     try
                     {
-                        var jObjectSettings = new JObject();
+                        JObject jObjectSettings = null;
                         var stringifySetting = stateAction.Settings?.ToString(Formatting.None);
                         
                         if (stringifySetting != null)

--- a/src/Take.Blip.Builder/Models/Action.cs
+++ b/src/Take.Blip.Builder/Models/Action.cs
@@ -45,7 +45,7 @@ namespace Take.Blip.Builder.Models
         /// <summary>
         /// The action settings for the specified type. Optional.
         /// </summary>
-        public JObject Settings { get; set; }
+        public JRaw Settings { get; set; }
 
         public void Validate()
         {


### PR DESCRIPTION
Chaging JObject to JRaw to improve memory usage on the below objects:
- Take.Blip.Builder.Models.Actions.Settings
- Take.Blip.Builder.Diagnostics.ActionTrace.ParsedSettings
