### PR TITLE
Allow Process Command Action using tunnel destination

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/OwnerSenderDecoratorTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/OwnerSenderDecoratorTests.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Lime.Protocol;
+using NSubstitute;
+using Take.Blip.Client;
+using Take.Blip.Client.Activation;
+using Xunit;
+
+namespace Take.Blip.Builder.UnitTests
+{
+    public class OwnerSenderDecoratorTests
+    {
+        private readonly ISender _sender;
+        private readonly Application _applicationIdentity;
+        private readonly OwnerSenderDecorator _ownerSenderDecorator;
+
+        public OwnerSenderDecoratorTests()
+        {
+            _sender = Substitute.For<ISender>();
+            _applicationIdentity = new Application { Identifier = "identity", Domain = "limeprotocol.org" };
+
+            OwnerContext.Create(new Identity("owner", "limeprotocol.org"));
+
+            _ownerSenderDecorator = new OwnerSenderDecorator(
+                _sender,
+                _applicationIdentity);
+        }
+
+        [Fact]
+        public async Task ProcessCommandShouldSetFromAsOwner()
+        {
+            // Arrange
+            var command = new Command("id")
+            {
+                Uri = new LimeUri("/uri"),
+                To = "postmaster@limeprotocol.org"
+            };
+
+            // Act
+            await _ownerSenderDecorator.ProcessCommandAsync(command, CancellationToken.None);
+
+            // Assert
+            await _sender
+                .Received(1)
+                .ProcessCommandAsync(
+                    Arg.Is<Command>(c => c.From.Name == "owner" && c.From.Domain == "limeprotocol.org"),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ProcessCommandShouldIgnoreOwner()
+        {
+            // Arrange
+            var command = new Command("id")
+            {
+                Uri = new LimeUri("/uri"),
+                To = "postmaster@limeprotocol.org",
+                Metadata = new Dictionary<string, string>
+                {
+                    { $"builder.{Constants.IGNORE_OWNER_CONTEXT}", "True" }
+                }
+            };
+
+            // Act
+            await _ownerSenderDecorator.ProcessCommandAsync(command, CancellationToken.None);
+
+            // Assert
+            await _sender
+                .Received(1)
+                .ProcessCommandAsync(
+                    Arg.Is<Command>(c => c.From == null),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ProcessCommandShouldNotIgnoreOwner()
+        {
+            // Arrange
+            var command = new Command("id")
+            {
+                Uri = new LimeUri("/uri"),
+                To = "postmaster@limeprotocol.org",
+                Metadata = new Dictionary<string, string>
+                {
+                    { $"builder.{Constants.IGNORE_OWNER_CONTEXT}", "False" }
+                }
+            };
+
+            // Act
+            await _ownerSenderDecorator.ProcessCommandAsync(command, CancellationToken.None);
+
+            // Assert
+            await _sender
+                .Received(1)
+                .ProcessCommandAsync(
+                    Arg.Is<Command>(c => c.From.Name == "owner" && c.From.Domain == "limeprotocol.org"),
+                    Arg.Any<CancellationToken>());
+        }
+    }
+}

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -1,13 +1,12 @@
-﻿using Lime.Protocol;
-using Lime.Protocol.Serialization;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Lime.Protocol;
+using Lime.Protocol.Serialization;
+using Newtonsoft.Json.Linq;
 using Take.Blip.Client;
-using Take.Blip.Client.Activation;
 
 namespace Take.Blip.Builder.Actions.ProcessCommand
 {
@@ -65,13 +64,10 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
             }
 
             var command = settings.ToObject<Command>(LimeSerializerContainer.Serializer);
-            if (command.Method == CommandMethod.Get)
-            {
-                command.Metadata = new Dictionary<string, string> {
-                    { "server.shouldStore", "true" },
-                    { "app.name", "BuilderAction" },
-                };
-            }
+            command.Metadata = new Dictionary<string, string> {
+                { "server.shouldStore", "true" },
+                { "app.name", "BuilderAction" },
+            };
 
             return command;
         }

--- a/src/Take.Blip.Builder/Constants.cs
+++ b/src/Take.Blip.Builder/Constants.cs
@@ -40,5 +40,10 @@ namespace Take.Blip.Builder
         /// Denominator percentage
         /// </summary>
         public const int PERCENTAGE_DENOMINATOR = 100;
+
+        /// <summary>
+        /// Indicates if the tunnel owner context should be ignored on proccess command action
+        /// </summary>
+        public const string IGNORE_OWNER_CONTEXT = "ignoreOwnerContext";
     }
 }

--- a/src/Take.Blip.Builder/OwnerSenderDecorator.cs
+++ b/src/Take.Blip.Builder/OwnerSenderDecorator.cs
@@ -44,6 +44,16 @@ namespace Take.Blip.Builder
         {
             if (command.From == null)
             {
+                var ignoreOwnerContext = false;
+                if (command.Metadata?.TryGetValue($"builder.{Constants.IGNORE_OWNER_CONTEXT}", out var ignoreOwnerContextMetadata) == true)
+                {
+                    ignoreOwnerContext = bool.Parse(ignoreOwnerContextMetadata);
+                }
+                if (ignoreOwnerContext)
+                {
+                    return command;
+                }
+
                 var owner = OwnerContext.Owner;
                 if (owner != null &&
                     owner != _applicationIdentity)


### PR DESCRIPTION
Some commands must be processed in the name of the tunnel destination, instead of the tunnel owner. When trying to perform process command action when tunnel owner context is enabled, this can be an issue.

This PR adds an addition stating to the action to allow user specify if the command should be made in the name of the tunnel owner ou the tunnel destination.