### PR TITLE
Updated pipeline template version to v.1.4.32

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ resources:
   - repository: templates
     type: git
     name: Operações/template-take-blip
-    ref: refs/tags/v1.4.29
+    ref: refs/tags/v1.4.32
 
 extends:
   template: template-pipeline.yml@templates    


### PR DESCRIPTION
Updated pipeline template version to v.1.4.32.
This version fixes the error when doesn't register tags after release creation