### PR TITLE
Fix input expiration

### DIFF
--- a/src/Take.Blip.Client/Receivers/ContactMessageReceiverBase.cs
+++ b/src/Take.Blip.Client/Receivers/ContactMessageReceiverBase.cs
@@ -9,6 +9,7 @@ using Take.Blip.Client.Extensions.Contacts;
 using Take.Blip.Client.Extensions.Directory;
 using Microsoft.Extensions.Caching.Memory;
 using Serilog;
+using Take.Blip.Client.Content;
 
 namespace Take.Blip.Client.Receivers
 {
@@ -47,11 +48,20 @@ namespace Take.Blip.Client.Receivers
 
         public virtual async Task ReceiveAsync(Message envelope, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var identity = envelope.From.ToIdentity();
+            var identity = GetIdentity(envelope);
             var contact = await GetContactAsync(identity, cancellationToken);
             await ReceiveAsync(envelope, contact, cancellationToken);
         }
-        
+
+        private static Identity GetIdentity(Message envelope)
+        {
+            if (envelope.Content is InputExpiration)
+            {
+                return (envelope.Content as InputExpiration).Identity;
+            }
+            return envelope.From.ToIdentity();
+        }
+
         protected MemoryCache ContactCache { get; }
 
         /// <summary>

--- a/src/Take.Blip.Client/Receivers/ContactMessageReceiverBase.cs
+++ b/src/Take.Blip.Client/Receivers/ContactMessageReceiverBase.cs
@@ -55,11 +55,7 @@ namespace Take.Blip.Client.Receivers
 
         private static Identity GetIdentity(Message envelope)
         {
-            if (envelope.Content is InputExpiration)
-            {
-                return (envelope.Content as InputExpiration).Identity;
-            }
-            return envelope.From.ToIdentity();
+            return envelope.Content is InputExpiration ? (envelope.Content as InputExpiration).Identity : envelope.From.ToIdentity();
         }
 
         protected MemoryCache ContactCache { get; }


### PR DESCRIPTION
Change identity from bot shortname to contact identity in ContactMessageReceiverBase for "input expiration" type messages