### PR TITLE
feat: add status code warning for HTTP action

### DIFF
--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -133,7 +133,7 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
 
                 if (currentActionTrace.ParsedSettings != null)
                 {
-                    currentActionTrace.ParsedSettings["#responseStatusCode"] = statusCode;
+                    currentActionTrace.ParsedSettings["responseStatusCode"] = statusCode;
                 }
             }
             catch (Exception ex)

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -133,7 +133,7 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
 
                 if (currentActionTrace.ParsedSettings != null)
                 {
-                    currentActionTrace.ParsedSettings["responseStatusCode"] = statusCode;
+                    currentActionTrace.ParsedSettings["responseStatusCode"] = statusCode.ToString();
                 }
             }
             catch (Exception ex)

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -89,6 +89,11 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
                 {
                     await context.SetVariableAsync(settings.ResponseBodyVariable, responseBody, cancellationToken);
                 }
+
+                if (responseStatus != 200)
+                {
+                    PushStatusCodeWarning(context);
+                }
             }
             catch (Exception ex)
             {
@@ -103,13 +108,37 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
 
         private void PushTimeoutWarning(IContext context)
         {
-            var warningMessage =
-                $"The process http command action has timed out.";
+            const string warningMessage = "The process http command action has timed out.";
 
             var currentActionTrace = context.GetCurrentActionTrace();
             if (currentActionTrace != null)
             {
                 currentActionTrace.Warning = warningMessage;
+            }
+        }
+
+        private void PushStatusCodeWarning(IContext context, int statusCode = 0)
+        {
+            try
+            {
+                const string warningMessage = "The process http command action has returned non-success status code.";
+
+                var currentActionTrace = context.GetCurrentActionTrace();
+                if (currentActionTrace == null)
+                {
+                    return;
+                }
+
+                currentActionTrace.Warning = warningMessage;
+
+                if (currentActionTrace.ParsedSettings != null)
+                {
+                    currentActionTrace.ParsedSettings["#responseStatusCode"] = statusCode;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "An error occurred while pushing status code warning");
             }
         }
 

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -119,26 +119,12 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
 
         private void PushStatusCodeWarning(IContext context, int statusCode = 0)
         {
-            try
+            var warningMessage = $"HTTP command action status code response: {statusCode}";
+
+            var currentActionTrace = context.GetCurrentActionTrace();
+            if (currentActionTrace != null)
             {
-                const string warningMessage = "The process http command action has returned non-success status code.";
-
-                var currentActionTrace = context.GetCurrentActionTrace();
-                if (currentActionTrace == null)
-                {
-                    return;
-                }
-
                 currentActionTrace.Warning = warningMessage;
-
-                if (currentActionTrace.ParsedSettings != null)
-                {
-                    currentActionTrace.ParsedSettings["responseStatusCode"] = statusCode.ToString();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "An error occurred while pushing status code warning");
             }
         }
 


### PR DESCRIPTION
To be able to track down non-success status code from our HTTP action we need to set it as a warning for our Trace mechanism