### PR TITLE
#649060 - lime version to 0.12.60

### DIFF
--- a/src/Take.Blip.Client/Take.Blip.Client.csproj
+++ b/src/Take.Blip.Client/Take.Blip.Client.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Lime.Messaging" Version="0.12.60" />
     <PackageReference Include="Lime.Protocol" Version="0.12.60" />
-    <PackageReference Include="Lime.Transport.Tcp" Version="0.10.81-beta" />
+    <PackageReference Include="Lime.Transport.Tcp" Version="0.12.60" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />


### PR DESCRIPTION
Lime.Transport.Tcp is at a different version as Lime.Protocol. 