### PR TITLE
#666475 - Update dependencies of Takenet.Iris.Messaging projects

### DIFF
--- a/src/Take.Blip.Client/Take.Blip.Client.csproj
+++ b/src/Take.Blip.Client/Take.Blip.Client.csproj
@@ -17,20 +17,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lime.Messaging" Version="0.12.60" />
-    <PackageReference Include="Lime.Protocol" Version="0.12.60" />
-    <PackageReference Include="Lime.Transport.Tcp" Version="0.12.60" />
+    <PackageReference Include="Lime.Messaging" Version="0.12.102" />
+    <PackageReference Include="Lime.Protocol" Version="0.12.102" />
+    <PackageReference Include="Lime.Transport.Tcp" Version="0.12.102" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="SmartFormat.NET" Version="2.1.0.2" />
-    <PackageReference Include="Takenet.Iris.Messaging.Analytics" Version="21.93.7297" />
-    <PackageReference Include="Takenet.Iris.Messaging.ArtificialIntelligence" Version="21.93.7297" />
-    <PackageReference Include="Takenet.Iris.Messaging.Desk" Version="21.93.7297" />
-    <PackageReference Include="Takenet.Iris.Messaging.Media" Version="21.93.7297" />
-    <PackageReference Include="Takenet.Iris.Messaging.Portal" Version="21.93.7297" />
+    <PackageReference Include="Takenet.Iris.Messaging.ActiveCampaign" Version="24.0.19" />
+    <PackageReference Include="Takenet.Iris.Messaging.Analytics" Version="24.0.19" />
+    <PackageReference Include="Takenet.Iris.Messaging.ArtificialIntelligence" Version="24.0.19" />
+    <PackageReference Include="Takenet.Iris.Messaging.Desk" Version="24.0.19" />
+    <PackageReference Include="Takenet.Iris.Messaging.Media" Version="24.0.19" />
+    <PackageReference Include="Takenet.Iris.Messaging.Portal" Version="24.0.19" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
In order to be possible to use the ActiveCampaign objects into the Blip.Client, this PR updates the dependencies of csproj to include the new ActiveCampaign dependency and update anothers projects of Iris and Messagings.