### PR TITLE
Refactor: remove /context API call to improve performance

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/ExtensionContextTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/ExtensionContextTests.cs
@@ -100,11 +100,6 @@ namespace Take.Blip.Builder.UnitTests
             {
                 throw new NotImplementedException();
             }
-
-            public Task<DocumentCollection> GetIdentitiesAsync(int skip = 0, int take = 100, CancellationToken cancellationToken = default(CancellationToken))
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/src/Take.Blip.Client/Extensions/Context/ContextExtension.cs
+++ b/src/Take.Blip.Client/Extensions/Context/ContextExtension.cs
@@ -71,13 +71,6 @@ namespace Take.Blip.Client.Extensions.Context
                 $"{Smart.Format(CONTEXT, new { identity = Uri.EscapeDataString(identity.ToString()) })}?{nameof(skip)}={skip}&{nameof(take)}={take}");
             return ProcessCommandAsync<DocumentCollection>(requestCommand, cancellationToken);
         }
-
-        public Task<DocumentCollection> GetIdentitiesAsync(int skip = 0, int take = 100, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var requestCommand = CreateGetCommandRequest($"{CONTEXTS}?{nameof(skip)}={skip}&{nameof(take)}={take}");
-            return ProcessCommandAsync<DocumentCollection>(requestCommand, cancellationToken);
-        }
-
         private static string GetVariableRequestUri(Identity identity, string variableName) 
             => Smart.Format(
                 CONTEXT_VARIABLE,

--- a/src/Take.Blip.Client/Extensions/Context/IContextExtension.cs
+++ b/src/Take.Blip.Client/Extensions/Context/IContextExtension.cs
@@ -69,13 +69,6 @@ namespace Take.Blip.Client.Extensions.Context
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<DocumentCollection> GetVariablesAsync(Identity identity, int skip = 0, int take = 100, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Gets the identities that have stored contexts.
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<DocumentCollection> GetIdentitiesAsync(int skip = 0, int take = 100, CancellationToken cancellationToken = default(CancellationToken));
     }
 
     public static class ContextExtensionExtensions


### PR DESCRIPTION
Description:
The /context endpoint has been removed due to its impact on application performance and limited business applicability. This endpoint previously returned contacts with context variables associated with the bot. By removing this call, we aim to optimize resource usage and improve overall system performance.

Impact:

Enhances performance by reducing unnecessary data retrieval.
Removes unused API functionality to streamline operations.
Testing:
Ensure that dependent services or components do not rely on the /context endpoint. Validate that performance metrics align with expected improvements after removal.