### PR TITLE
Feature/774032 create metadata on action

### DIFF
--- a/src/Samples/Builder.Console/Builder.Console.csproj
+++ b/src/Samples/Builder.Console/Builder.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/HelpDesk/HelpDesk.csproj
+++ b/src/Samples/HelpDesk/HelpDesk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/MediaReceiver/MediaReceiver.csproj
+++ b/src/Samples/MediaReceiver/MediaReceiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Version>1.0.0</Version>    
     <OutputType>Exe</OutputType>    
   </PropertyGroup>

--- a/src/Samples/MessageTypes/MessageTypes.csproj
+++ b/src/Samples/MessageTypes/MessageTypes.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Version>1.0.0</Version>    
     <OutputType>Exe</OutputType>    
   </PropertyGroup>

--- a/src/Samples/Navigation/Navigation.csproj
+++ b/src/Samples/Navigation/Navigation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Programmatically/Programmatically.csproj
+++ b/src/Samples/Programmatically/Programmatically.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Take.Blip.Builder.UnitTests/Take.Blip.Builder.UnitTests.csproj
+++ b/src/Take.Blip.Builder.UnitTests/Take.Blip.Builder.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -2,6 +2,7 @@
 using Lime.Protocol.Serialization;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,8 +27,10 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
         public async Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-            if (settings == null) throw new ArgumentNullException(nameof(settings), $"The settings are required for '{nameof(ProcessCommandAction)}' action");
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings), $"The settings are required for '{nameof(ProcessCommandAction)}' action");
 
             string variable = null;
 
@@ -41,7 +44,8 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
             var resultCommand = await _sender.ProcessCommandAsync(command, cancellationToken);
 
-            if (string.IsNullOrWhiteSpace(variable)) return;
+            if (string.IsNullOrWhiteSpace(variable))
+                return;
 
             var resultCommandJson = _envelopeSerializer.Serialize(resultCommand);
             await context.SetVariableAsync(variable, resultCommandJson, cancellationToken);
@@ -49,14 +53,29 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
         private Command ConvertToCommand(JObject settings)
         {
-            
+
             if (settings.TryGetValue(Command.TYPE_KEY, out var type)
                 && Regex.IsMatch(type.ToString(), SERIALIZABLE_PATTERN, default, Constants.REGEX_TIMEOUT)
                 && settings.TryGetValue(Command.RESOURCE_KEY, out var resource))
             {
                 settings.Property(Command.RESOURCE_KEY).Value = JObject.Parse(resource.ToString());
             }
-            return settings.ToObject<Command>(LimeSerializerContainer.Serializer);
+
+            var command = settings.ToObject<Command>(LimeSerializerContainer.Serializer);
+            InsertMetadataToRouteCommandProperly(command);
+
+            return command;
+        }
+
+        private void InsertMetadataToRouteCommandProperly(Command command)
+        {
+            if (command.Metadata is null)
+                command.Metadata = new Dictionary<string, string>();
+
+            if (command.Metadata.ContainsKey(Client.Constants.ENVELOPE_MUST_BE_ROUTED_TO_SERVER_KEY))
+                command.Metadata[Client.Constants.ENVELOPE_MUST_BE_ROUTED_TO_SERVER_KEY] = "true";
+            else
+                command.Metadata.Add(Client.Constants.ENVELOPE_MUST_BE_ROUTED_TO_SERVER_KEY, "true");
         }
     }
 }

--- a/src/Take.Blip.Client.UnitTests/Take.Blip.Client.UnitTests.csproj
+++ b/src/Take.Blip.Client.UnitTests/Take.Blip.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Take.Blip.Client/Constants.cs
+++ b/src/Take.Blip.Client/Constants.cs
@@ -19,5 +19,7 @@ namespace Take.Blip.Client
         public const string DEFAULT_STATE = "default";
 
         public const string ORIGINAL_SUBFLOW_REDIRECT_FROM = "originalSubflowRedirectFrom";
+
+        public const string ENVELOPE_MUST_BE_ROUTED_TO_SERVER_KEY = "#envelope.sendToServerRequired";
     }
 }


### PR DESCRIPTION
This pull request creates a new metadata on `ProcessCommandAction`, forcing this command to be sent to server to be authorized and validated properly

Also, we're removing the unused frameworks avoiding some compilation problems