### PR TITLE
#809669 - Library update

### DIFF
--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
     <PackageReference Include="Handlebars.Net.Extension.Json" Version="1.0.0" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="Take.Elephant" Version="0.10.2" />
     <PackageReference Include="Take.Jint.Unnoficial" Version="4.0.4" />

--- a/src/Take.Blip.Client/Take.Blip.Client.csproj
+++ b/src/Take.Blip.Client/Take.Blip.Client.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Lime.Messaging" Version="0.12.60" />
     <PackageReference Include="Lime.Protocol" Version="0.12.60" />
     <PackageReference Include="Lime.Transport.Tcp" Version="0.12.60" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
@@ -34,5 +34,5 @@
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
This PR updates libraries that have vulnerabilities

Microsoft.Extensions.Caching.Memory to [8.0.1](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory)
Microsoft.Extensions.DependencyModel to [8.0.2](https://www.nuget.org/packages/Microsoft.Extensions.DependencyModel)