### PR TITLE
Bugfix/858382 fix parse form encoded body

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -90,7 +90,7 @@ namespace Take.Blip.Builder.UnitTests
             var expectedUri = "/ping";
 
 
-            // Use reflection se for método privado
+            // Use reflection se for mï¿½todo privado
             var method = typeof(FlowManager)
                 .GetMethod("RestoreBodyStringWithSecrets", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
@@ -99,7 +99,7 @@ namespace Take.Blip.Builder.UnitTests
 
             // Assert
             var resultObj = JObject.Parse(result);
-            resultObj["secretUrlBlip"].Value<bool>().ShouldBeTrue();
+            resultObj["SecretUrlBlip"].Value<bool>().ShouldBeTrue();
 
             var body = JObject.Parse(resultObj["body"].ToString());
             body["secret"].Value<string>().ShouldBe(expectedSecret);
@@ -490,7 +490,7 @@ namespace Take.Blip.Builder.UnitTests
                 }
             };
             var target = GetTarget();
-            var functionDocument = new Function { FunctionContent = "function content", UserIdentity = "teste",FunctionDescription = "", FunctionId = Guid.NewGuid(), FunctionName = "",FunctionParameters = "",TenantId = ""};
+            var functionDocument = new Function { FunctionContent = "function content", UserIdentity = "teste", FunctionDescription = "", FunctionId = Guid.NewGuid(), FunctionName = "", FunctionParameters = "", TenantId = "" };
 
             BuilderExtension.GetFunctionOnBlipFunctionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(functionDocument);
 

--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -90,7 +90,7 @@ namespace Take.Blip.Builder.UnitTests
             var expectedUri = "/ping";
 
 
-            // Use reflection se for m�todo privado
+            // Use reflection se for método privado
             var method = typeof(FlowManager)
                 .GetMethod("RestoreBodyStringWithSecrets", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 

--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -541,7 +541,7 @@ namespace Take.Blip.Builder
 
                 string realAction = stateAction.Type;
 
-                if(stateAction.Type == ACTION_BLIP_FUNCTION)
+                if (stateAction.Type == ACTION_BLIP_FUNCTION)
                 {
                     stateAction.Type = ACTION_EXECUTE_SCRIPT_V2;
                 }
@@ -599,7 +599,7 @@ namespace Take.Blip.Builder
 
                         if (actionTrace != null)
                         {
-                            if(realAction == ACTION_PROCESS_HTTP)
+                            if (realAction == ACTION_PROCESS_HTTP)
                             {
                                 var result = RestoreBodyStringWithSecrets(stringfySettingsCopy, stringifySetting);
                                 actionTrace.ParsedSettings = new JRaw(string.IsNullOrEmpty(result) ? stringifySetting : result);
@@ -607,11 +607,11 @@ namespace Take.Blip.Builder
                             }
                             else
                             {
-                            actionTrace.ParsedSettings = new JRaw(stringifySetting);
+                                actionTrace.ParsedSettings = new JRaw(stringifySetting);
 
                             }
                         }
-                        
+
                         using (LogContext.PushProperty(nameof(BuilderException.MessageId), lazyInput?.Message?.Id))
                         using (LogContext.PushProperty(nameof(Action.Settings), jObjectSettings, true))
                             await action.ExecuteAsync(context, jObjectSettings, linkedCts.Token);
@@ -778,13 +778,22 @@ namespace Take.Blip.Builder
 
         private static Dictionary<string, string> ParseFormEncoded(string formEncoded)
         {
+            if (string.IsNullOrEmpty(formEncoded))
+            {
+                return new Dictionary<string, string>();
+            }
+
             return formEncoded
                 .Split('&')
-                .Select(part => part.Split('='))
-                .Where(pair => pair.Length == 2)
-                .ToDictionary(
-                    pair => Uri.UnescapeDataString(pair[0]),
-                    pair => Uri.UnescapeDataString(pair[1]));
+                .Where(pairString => !string.IsNullOrWhiteSpace(pairString))
+                .Select(pairString =>
+                {
+                    string[] keyValue = pairString.Split(new[] { '=' }, 2);
+                    var key = Uri.UnescapeDataString(keyValue[0]);
+                    var value = keyValue.Length == 2 ? Uri.UnescapeDataString(keyValue[1]) : string.Empty;
+                    return new { Key = key, Value = value };
+                })
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
         }
 
         private Boolean IsContextVariable(string stateId)


### PR DESCRIPTION
This PR solves this [incident](https://dev.azure.com/curupira/Opera%C3%A7%C3%B5es/_workitems/edit/858382).

This method, when receiving a x-www-form-urlencoded body type, is truncating the body, and the request does not work:
![image](https://github.com/user-attachments/assets/1bbdacb6-d137-4a5e-817a-ce3cb4974f78)

When it stores the body in a variable and sends the variable through the body the request works: 
![image](https://github.com/user-attachments/assets/61a0ffe0-3ec2-4d1c-94aa-36cc680cf0d0)