### PR TITLE
feat: Add output variables and local custom actions support

### DIFF
--- a/src/Take.Blip.Builder/Actions/ActionBase.cs
+++ b/src/Take.Blip.Builder/Actions/ActionBase.cs
@@ -8,18 +8,27 @@ namespace Take.Blip.Builder.Actions
 {
     public abstract class ActionBase<TSettings> : IAction where TSettings : IValidable
     {
-        protected ActionBase(string type)
+        protected ActionBase(string type, string[]? outputVariables = null)
         {
-            if (string.IsNullOrWhiteSpace(type)) throw new ArgumentException("Action type cannot be null or whitespace.", nameof(type));
+            if (string.IsNullOrWhiteSpace(type))
+                throw new ArgumentException("Action type cannot be null or whitespace.", nameof(type));
+
             Type = type;
+
+            if (outputVariables != null)
+                OutputVariables = outputVariables;
         }
 
         public string Type { get; }
 
+        public string[]? OutputVariables { get; }
+
         public Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-            if (settings == null) throw new ArgumentNullException(nameof(settings));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
 
             var validableSettings = settings.ToObject<TSettings>();
             validableSettings.Validate();

--- a/src/Take.Blip.Builder/Actions/CreateTicket/CreateTicketAction.cs
+++ b/src/Take.Blip.Builder/Actions/CreateTicket/CreateTicketAction.cs
@@ -12,8 +12,10 @@ namespace Take.Blip.Builder.Actions.CreateTicket
         private readonly IHelpDeskExtension _helpDeskExtension;
         private readonly Application _application;
 
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(CreateTicketSettings.Variable) };
+
         public CreateTicketAction(IHelpDeskExtension helpDeskExtension, Application application)
-            : base(nameof(CreateTicket))
+            : base(nameof(CreateTicket), OUTPUT_PARAMETERS_NAME)
         {
             _helpDeskExtension = helpDeskExtension;
             _application = application;

--- a/src/Take.Blip.Builder/Actions/ExecuteScript/ExecuteScriptAction.cs
+++ b/src/Take.Blip.Builder/Actions/ExecuteScript/ExecuteScriptAction.cs
@@ -22,8 +22,10 @@ namespace Take.Blip.Builder.Actions.ExecuteScript
         const string BRAZIL_TIMEZONE = "E. South America Standard Time";
         const string LOCAL_TIMEZONE_SEPARATOR = "builder:#localTimeZone";
 
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(ExecuteScriptSettings.OutputVariable) };
+
         public ExecuteScriptAction(IConfiguration configuration, ILogger logger)
-            : base(nameof(ExecuteScript))
+            : base(nameof(ExecuteScript), OUTPUT_PARAMETERS_NAME)
         {
             _configuration = configuration;
             _logger = logger;

--- a/src/Take.Blip.Builder/Actions/ExecuteScriptV2/ExecuteScriptV2Action.cs
+++ b/src/Take.Blip.Builder/Actions/ExecuteScriptV2/ExecuteScriptV2Action.cs
@@ -20,12 +20,14 @@ namespace Take.Blip.Builder.Actions.ExecuteScriptV2
         private readonly IHttpClient _httpClient;
         private readonly ILogger _logger;
 
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(ExecuteScriptV2Settings.OutputVariable) };
+
         /// <inheritdoc />
         public ExecuteScriptV2Action(
             IConfiguration configuration,
             IHttpClient httpClient,
             ILogger logger)
-            : base(nameof(ExecuteScriptV2))
+            : base(nameof(ExecuteScriptV2), OUTPUT_PARAMETERS_NAME)
         {
             HostSettings.CustomAttributeLoader = new LowerCaseMembersLoader();
 

--- a/src/Take.Blip.Builder/Actions/ExecuteTemplate/ExecuteTemplateAction.cs
+++ b/src/Take.Blip.Builder/Actions/ExecuteTemplate/ExecuteTemplateAction.cs
@@ -16,8 +16,10 @@ namespace Take.Blip.Builder.Actions.ExecuteTemplate
     {
         private readonly ILogger _logger;
         private readonly IHandlebars _handlebars;
-        
-        public ExecuteTemplateAction(IHandlebars handlebars, ILogger logger) : base(nameof(ExecuteTemplate))
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(ExecuteTemplateSettings.OutputVariable) };
+
+        public ExecuteTemplateAction(IHandlebars handlebars, ILogger logger) 
+            : base(nameof(ExecuteTemplate), OUTPUT_PARAMETERS_NAME)
         {
             _logger = logger;
             _handlebars = handlebars;
@@ -44,7 +46,7 @@ namespace Take.Blip.Builder.Actions.ExecuteTemplate
                 _logger.Warning(ex, "Unexpected error while execute action Execute Template");
                 throw;
             }
-            
+
             await SetScriptResultAsync(context, settings, result, cancellationToken);
         }
 
@@ -65,7 +67,7 @@ namespace Take.Blip.Builder.Actions.ExecuteTemplate
             }
             return obj;
         }
-        
+
         private async Task SetScriptResultAsync(
             IContext context, ExecuteTemplateSettings settings, string result, CancellationToken cancellationToken)
         {
@@ -81,7 +83,7 @@ namespace Take.Blip.Builder.Actions.ExecuteTemplate
         private Dictionary<string, object> CopyArgumentsToDictionary(JObject arguments)
         {
             var obj = new Dictionary<string, object>();
-            foreach (var property in arguments.Properties())    
+            foreach (var property in arguments.Properties())
             {
                 try
                 {
@@ -94,7 +96,7 @@ namespace Take.Blip.Builder.Actions.ExecuteTemplate
                     {
                         obj[property.Name] = property.Value;
                     }
-                }                
+                }
             }
             return obj;
         }

--- a/src/Take.Blip.Builder/Actions/IAction.cs
+++ b/src/Take.Blip.Builder/Actions/IAction.cs
@@ -9,6 +9,8 @@ namespace Take.Blip.Builder.Actions
     {
         string Type { get; }
 
+        string[]? OutputVariables { get; }
+
         Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/Actions/MergeContact/MergeContactAction.cs
+++ b/src/Take.Blip.Builder/Actions/MergeContact/MergeContactAction.cs
@@ -21,6 +21,8 @@ namespace Take.Blip.Builder.Actions.MergeContact
 
         public string Type => nameof(MergeContact);
 
+        public string[]? OutputVariables => null;
+
         public async Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));

--- a/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessCommand/ProcessCommandAction.cs
@@ -19,6 +19,7 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
         private readonly IConfiguration _configuration;
 
         private const string SERIALIZABLE_PATTERN = @".+[/|\+]json$";
+        private const string OUTPUT_VARIABLE_PROPERTY = "variable";
 
         public ProcessCommandAction(ISender sender, IEnvelopeSerializer envelopeSerializer, IConfiguration configuration)
         {
@@ -29,6 +30,8 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
         public string Type => nameof(ProcessCommand);
 
+        public string[]? OutputVariables => new[] { OUTPUT_VARIABLE_PROPERTY };
+
         public async Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
             if (context == null)
@@ -38,7 +41,7 @@ namespace Take.Blip.Builder.Actions.ProcessCommand
 
             string variable = null;
 
-            if (settings.TryGetValue(nameof(variable), out var variableToken))
+            if (settings.TryGetValue(OUTPUT_VARIABLE_PROPERTY, out var variableToken))
             {
                 variable = variableToken.ToString().Trim('"');
             }

--- a/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessContentAssistant/ProcessContentAssistantAction.cs
@@ -13,10 +13,10 @@ namespace Take.Blip.Builder.Actions.ProcessContentAssistant
     public class ProcessContentAssistantAction : ActionBase<ProcessContentAssistantSettings>
     {
         private readonly IArtificialIntelligenceExtension _artificialIntelligenceExtension;
-
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(ProcessContentAssistantSettings.OutputVariable) };
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-        public ProcessContentAssistantAction(IArtificialIntelligenceExtension artificialIntelligenceExtension) : base(nameof(ProcessContentAssistant))
+        public ProcessContentAssistantAction(IArtificialIntelligenceExtension artificialIntelligenceExtension) : base(nameof(ProcessContentAssistant), OUTPUT_PARAMETERS_NAME)
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         {
             _artificialIntelligenceExtension = artificialIntelligenceExtension;

--- a/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
+++ b/src/Take.Blip.Builder/Actions/ProcessHttp/ProcessHttpAction.cs
@@ -27,8 +27,14 @@ namespace Take.Blip.Builder.Actions.ProcessHttp
         private readonly IVariableReplacer _variableReplacer;
         private readonly ISensitiveInfoReplacer _sensitiveInfoReplacer;
 
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[]
+        {
+            nameof(ProcessHttpSettings.ResponseStatusVariable),
+            nameof(ProcessHttpSettings.ResponseBodyVariable)
+        };
+
         public ProcessHttpAction(IHttpClient httpClient, ILogger logger, IConfiguration configuration,  ISensitiveInfoReplacer sensitiveInfoReplacer, IVariableReplacer variableReplacer)
-            : base(nameof(ProcessHttp))
+            : base(nameof(ProcessHttp), OUTPUT_PARAMETERS_NAME)
         {
             _httpClient = httpClient;
             _logger = logger;

--- a/src/Take.Blip.Builder/Actions/Redirect/RedirectAction.cs
+++ b/src/Take.Blip.Builder/Actions/Redirect/RedirectAction.cs
@@ -20,6 +20,8 @@ namespace Take.Blip.Builder.Actions.Redirect
 
         public string Type => nameof(Redirect);
 
+        public string[]? OutputVariables => null;
+
         public Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));

--- a/src/Take.Blip.Builder/Actions/SendCommand/SendCommandAction.cs
+++ b/src/Take.Blip.Builder/Actions/SendCommand/SendCommandAction.cs
@@ -18,6 +18,8 @@ namespace Take.Blip.Builder.Actions.SendCommand
 
         public string Type => nameof(SendCommand);
 
+        public string[]? OutputVariables => null;
+
         public Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));

--- a/src/Take.Blip.Builder/Actions/SendMessage/SendMessageAction.cs
+++ b/src/Take.Blip.Builder/Actions/SendMessage/SendMessageAction.cs
@@ -20,6 +20,8 @@ namespace Take.Blip.Builder.Actions.SendMessage
 
         public string Type => nameof(SendMessage);
 
+        public string[]? OutputVariables => null;
+
         public async Task ExecuteAsync(IContext context, JObject settings, CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));

--- a/src/Take.Blip.Builder/Actions/SetVariable/SetVariableAction.cs
+++ b/src/Take.Blip.Builder/Actions/SetVariable/SetVariableAction.cs
@@ -6,8 +6,10 @@ namespace Take.Blip.Builder.Actions.SetVariable
 {
     public class SetVariableAction : ActionBase<SetVariableSettings>
     {
+        private static readonly string[] OUTPUT_PARAMETERS_NAME = new string[] { nameof(SetVariableSettings.Variable) };
+
         public SetVariableAction()
-            : base(nameof(SetVariable))
+            : base(nameof(SetVariable), OUTPUT_PARAMETERS_NAME)
         {
             
         }

--- a/src/Take.Blip.Builder/BasicFlowSemaphore.cs
+++ b/src/Take.Blip.Builder/BasicFlowSemaphore.cs
@@ -7,7 +7,7 @@ using Take.Blip.Builder.Storage;
 
 namespace Take.Blip.Builder
 {
-    class BasicFlowSemaphore: IFlowSemaphore
+    class BasicFlowSemaphore : IFlowSemaphore
     {
         private readonly INamedSemaphore _namedSemaphore;
 
@@ -19,6 +19,11 @@ namespace Take.Blip.Builder
         }
 
         public Task<IAsyncDisposable> WaitAsync(Flow flow, Message message, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return _namedSemaphore.WaitAsync($"{flow.Id}:{userIdentity}", timeout, cancellationToken);
+        }
+
+        public Task<IAsyncDisposable> WaitAsync(Flow flow, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken)
         {
             return _namedSemaphore.WaitAsync($"{flow.Id}:{userIdentity}", timeout, cancellationToken);
         }

--- a/src/Take.Blip.Builder/Diagnostics/StateTrace.cs
+++ b/src/Take.Blip.Builder/Diagnostics/StateTrace.cs
@@ -26,6 +26,9 @@ namespace Take.Blip.Builder.Diagnostics
         [DataMember(Name = "afterStateChangedActions")]
         public ICollection<ActionTrace> AfterStateChangedActions { get; set; }
 
+        [DataMember(Name = "localCustomActions")]
+        public ICollection<ActionTrace> LocalCustomActions { get; set; }
+
         [DataMember(Name = "outputs")]
         public ICollection<OutputTrace> Outputs { get; set; }
 

--- a/src/Take.Blip.Builder/IFlowManager.cs
+++ b/src/Take.Blip.Builder/IFlowManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Lime.Messaging.Resources;
 using Lime.Protocol;
@@ -17,10 +18,20 @@ namespace Take.Blip.Builder
         /// <param name="message">The input message.</param>
         /// <param name="flow">The builder flow.</param>
         /// <param name="cancellationToken">The operation cancellation token.</param>
-        /// <param name="isActiveLogger"></param>
         /// <param name="messageContext">Context from Message Receiver. Its not mandatory.</param>
         /// <returns></returns>
         Task ProcessInputAsync(Message message, Flow flow, IContext messageContext, CancellationToken cancellationToken);
         Task ProcessInputAsync(Message message, Flow flow, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Process given an input command trigger
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="flow"></param>
+        /// <param name="stateId"></param>
+        /// <param name="actionId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<Dictionary<string, string>> ProcessCommandInputAsync(Command command, Flow flow, string stateId, string actionId, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/IFlowSemaphore.cs
+++ b/src/Take.Blip.Builder/IFlowSemaphore.cs
@@ -22,5 +22,15 @@ namespace Take.Blip.Builder
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         Task<IAsyncDisposable> WaitAsync(Flow flow, Message message, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Do semaphore lock to block the processing of two actions from the same contact and bot
+        /// </summary>
+        /// <param name="flow"></param>
+        /// <param name="userIdentity"></param>
+        /// <param name="timeout"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IAsyncDisposable> WaitAsync(Flow flow, Identity userIdentity, TimeSpan timeout, CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Blip.Builder/Models/Action.cs
+++ b/src/Take.Blip.Builder/Models/Action.cs
@@ -12,6 +12,11 @@ namespace Take.Blip.Builder.Models
     public class Action : IValidable
     {
         /// <summary>
+        /// The action identifier. It is used to identify the action in the conversation context and in the action trace. Required.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
         /// The action execution order, relative to the others in the same state. Optional.
         /// </summary>
         public int Order { get; set; }
@@ -35,7 +40,7 @@ namespace Take.Blip.Builder.Models
         /// TODO: Indicates if the action should be executed asynchronously, without blocking the input processing.
         /// </summary>
         public bool ExecuteAsynchronously { get; set; }
-        
+
         /// <summary>
         /// The action type name. Required.
         /// </summary>
@@ -49,7 +54,7 @@ namespace Take.Blip.Builder.Models
 
         public void Validate()
         {
-            this.ValidateObject();           
+            this.ValidateObject();
         }
 
         public ActionTrace ToTrace()

--- a/src/Take.Blip.Builder/Models/State.cs
+++ b/src/Take.Blip.Builder/Models/State.cs
@@ -56,12 +56,16 @@ namespace Take.Blip.Builder.Models
         /// </summary>
         public Output[] Outputs { get; set; }
 
-
         /// <summary>
         /// Stores additional JSON attributes that are not mapped in the type.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, JToken> ExtensionData { get; set; }
+
+        /// <summary>
+        /// Determines the local custom actions that should be executed when the state is activated.
+        /// </summary>
+        public Action[] LocalCustomActions { get; set; }
 
         public void Validate()
         {


### PR DESCRIPTION
This pull request introduces support for output variables in actions within the `Take.Blip.Builder` project. The most significant changes involve extending the `ActionBase` class and its derived classes to handle output variables, as well as adding new properties and constants to facilitate this functionality. Additionally, minor adjustments were made to improve code readability and add new trace data.

### Enhancements to action output handling:

* [`src/Take.Blip.Builder/Actions/ActionBase.cs`](diffhunk://#diff-6acff39a3abd73df87cfd3de3aaa6add8d976737cb5143393d464245e485f131L11-R31): Updated the `ActionBase` constructor to accept an optional `outputVariables` parameter and added the `OutputVariables` property to store these variables.
* [`src/Take.Blip.Builder/Actions/IAction.cs`](diffhunk://#diff-34ba135bb4c9993b52e5cafd614d3c7bc39f5a9886bf576abb1ee66e99d8e6a9R12-R13): Added the `OutputVariables` property to the `IAction` interface, enabling all actions to define output variables.
* Various action classes (`CreateTicketAction`, `ExecuteScriptAction`, `ExecuteScriptV2Action`, `ExecuteTemplateAction`, `ProcessContentAssistantAction`, `ProcessHttpAction`, `SetVariableAction`): Introduced static arrays to define output variable names and passed them to the `ActionBase` constructor. [[1]](diffhunk://#diff-b91cd01551d60153ae3700684eb4e733b51c92f8d3e28c64103f2228885598d5R15-R18) [[2]](diffhunk://#diff-dc53edf19ac4916fa6698c4a621af6c98e1b931ef6d51b12fcbfd62ea71cb7fbR25-R28) [[3]](diffhunk://#diff-270aecdc4d45472c56f2bc27b9fd0029b0abc109068a6f46fb9f19b5873a9df3R23-R30) [[4]](diffhunk://#diff-f6d45e3e5d5cf719e36c5c4165e9dd5951f1c79ddae6efc6af05fd1e0f21dff8R19-R22) [[5]](diffhunk://#diff-5f3544e95946b3bac5b5ddb19cca8b3b3df1ef79bcb6e20413e6de880d62d893L16-R19) [[6]](diffhunk://#diff-e096f632ff4dbfa361a28caf779a0662e0b6a0f89ea8d9c08957fa1e9aa9c39fR30-R37) [[7]](diffhunk://#diff-651ac7639564d07a1d54d04e166721d6b8c5eb0bf2e379c6b68a775b2be357d4R9-R12)
* [`ProcessCommandAction`](diffhunk://#diff-9eec00130995b3675544c98da3a2be04b9975ce7c305bdd0ef1d15b45d774a50R22): Added the `OutputVariables` property and replaced hardcoded variable names with constants for better maintainability. [[1]](diffhunk://#diff-9eec00130995b3675544c98da3a2be04b9975ce7c305bdd0ef1d15b45d774a50R22) [[2]](diffhunk://#diff-9eec00130995b3675544c98da3a2be04b9975ce7c305bdd0ef1d15b45d774a50R33-R34) [[3]](diffhunk://#diff-9eec00130995b3675544c98da3a2be04b9975ce7c305bdd0ef1d15b45d774a50L41-R44)

### Code readability and traceability improvements:

* [`src/Take.Blip.Builder/Diagnostics/StateTrace.cs`](diffhunk://#diff-0b2eab0886ceb951a06c049bc33993199271146a9de42168cbed316905be61ceR29-R31): Added a new `localCustomActions` property to trace local custom actions in diagnostics.
* [`src/Take.Blip.Builder/FlowManager.cs`](diffhunk://#diff-ae5c68a1936dba0988fe3e0f52a5ff14718f9cbf0276706787650d51d8074fdaL537-R537): Enhanced condition evaluation logic to account for `lazyInput` in state actions.

### Minor additions:

* [`src/Take.Blip.Builder/BasicFlowSemaphore.cs`](diffhunk://#diff-68685a72972bf4f1cef79474835cc7bc54a54d328a67d479db5b1399d1cb427cR25-R29): Added an overloaded `WaitAsync` method for better flexibility in semaphore handling.

These changes collectively improve the extensibility and traceability of actions while maintaining code clarity and consistency.