### PR TITLE
feat:  increase blip client sdk version AB#981237

### DIFF
--- a/src/Take.Blip.Ai.Bot.Monitoring.Abstractions/Take.Blip.Ai.Bot.Monitoring.Abstractions.csproj
+++ b/src/Take.Blip.Ai.Bot.Monitoring.Abstractions/Take.Blip.Ai.Bot.Monitoring.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Take.Blip.Builder/Take.Blip.Builder.csproj
+++ b/src/Take.Blip.Builder/Take.Blip.Builder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>
     <Version>0.1.2-beta</Version>

--- a/src/Take.Blip.Client.Console/Take.Blip.Client.Console.csproj
+++ b/src/Take.Blip.Client.Console/Take.Blip.Client.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.1.2-beta</Version>
     <Authors>takenet</Authors>
     <Company>take</Company>

--- a/src/Take.Blip.Client.TestKit/Take.Blip.Client.TestKit.csproj
+++ b/src/Take.Blip.Client.TestKit/Take.Blip.Client.TestKit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.1.0</Version>
     <Authors>takenet</Authors>
     <Company>Take</Company>

--- a/src/Take.Blip.Client.Web/Take.Blip.Client.Web.csproj
+++ b/src/Take.Blip.Client.Web/Take.Blip.Client.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>0.1.2-beta</Version>
   </PropertyGroup>

--- a/src/Take.Blip.Client/Take.Blip.Client.csproj
+++ b/src/Take.Blip.Client/Take.Blip.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.1.2-beta</Version>
     <Authors>takenet</Authors>
     <Company>take</Company>

--- a/src/Templates/Take.Blip.Client.ConsoleTemplate/Take.Blip.Client.ConsoleTemplate.csproj
+++ b/src/Templates/Take.Blip.Client.ConsoleTemplate/Take.Blip.Client.ConsoleTemplate.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.0.0</Version>    
     <OutputType>Exe</OutputType>    
   </PropertyGroup>
   
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Take.Blip.Client" Version="0.1.42" />
-    <PackageReference Include="Take.Blip.Client.Console" Version="0.1.42" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.537" />
+    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.537" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Templates/Take.Blip.Client.WebTemplate/Take.Blip.Client.WebTemplate.csproj
+++ b/src/Templates/Take.Blip.Client.WebTemplate/Take.Blip.Client.WebTemplate.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />    
-    <PackageReference Include="Take.Blip.Client" Version="0.1.42" />
-    <PackageReference Include="Take.Blip.Client.Web" Version="0.1.42" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.537" />
+    <PackageReference Include="Take.Blip.Client.Web" Version="0.7.537" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This pull request updates the target framework for several projects and templates to `.NET 8.0`, replacing older versions such as `netstandard2.1` and `netcoreapp2.0`. Additionally, it updates package references for template projects to use newer versions of `Take.Blip.Client` and related packages. These changes modernize the codebase and ensure compatibility with the latest .NET features and libraries.

Framework upgrade:

* Changed the `TargetFramework` property from `netstandard2.1` or `netcoreapp2.0` to `net8.0` in multiple project files, including `Take.Blip.Ai.Bot.Monitoring.Abstractions.csproj`, `Take.Blip.Builder.csproj`, `Take.Blip.Client.Console.csproj`, `Take.Blip.Client.TestKit.csproj`, `Take.Blip.Client.Web.csproj`, `Take.Blip.Client.csproj`, `Take.Blip.Client.ConsoleTemplate.csproj`, and `Take.Blip.Client.WebTemplate.csproj`. [[1]](diffhunk://#diff-cf4c2de91a4cb2222df4e85d9d9a490f8df7eb7b4cc1fa859a4af7d0dc03a535L4-R4) [[2]](diffhunk://#diff-d74c959cce5bad0a87dcd72e72109c6360cd44a656f1b292033b58764fe14633L4-R4) [[3]](diffhunk://#diff-827d67b7f46ba2efcb0b3a6ca3a70185cec1a3897326ec8491a86f74f2ccffd1L4-R4) [[4]](diffhunk://#diff-08a5a6ee6256cc4c42c373f9074f6bf6015b30ed0d759658d7c4545e6991d1a6L4-R4) [[5]](diffhunk://#diff-13e3e90d12ece0afaac6e2c88a6a7208b3c8539499fb1320a4963169d7f1c248L4-R4) [[6]](diffhunk://#diff-69aa07701c400a58e8bac6c3b711fddead1f2f52cbdc443a3638b591df178545L4-R4) [[7]](diffhunk://#diff-e94c1e5430196a2cb14bd75b043fa39c31531392cdd199c4ebc384352b37f235L3-R11) [[8]](diffhunk://#diff-0d9b59c56119ee13df75bfbdb3255fd21592a380770be3e202078741e4e19213L4-R10)

Template package updates:

* Updated `Take.Blip.Client` and related package references in `Take.Blip.Client.ConsoleTemplate.csproj` and `Take.Blip.Client.WebTemplate.csproj` from version `0.1.42` to `0.7.537`, and removed the `Microsoft.AspNetCore.All` package from the web template. [[1]](diffhunk://#diff-e94c1e5430196a2cb14bd75b043fa39c31531392cdd199c4ebc384352b37f235L3-R11) [[2]](diffhunk://#diff-0d9b59c56119ee13df75bfbdb3255fd21592a380770be3e202078741e4e19213L4-R10)