### PR TITLE
chore: Adds tests and updates Lime dependencies AB#1025468

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/FlowManagerTests.cs
@@ -619,6 +619,8 @@ namespace Take.Blip.Builder.UnitTests
         public async Task FlowWithInvalidStateIdOnOutputConditionsShouldReturnFlowConstructionException()
         {
             // Arrange
+            var input = new PlainText() { Text = "Test" };
+            Message.Content = input;
             var stateIdVariable = "{{variable.doesntExist}}";
             var flow = new Flow()
             {
@@ -640,6 +642,11 @@ namespace Take.Blip.Builder.UnitTests
                     }
                 }
             };
+
+            // Setup the context to return null for the non-existent variable
+            Context.GetVariableAsync("variable.doesntExist", Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(Task.FromResult((string)null));
+            Context.GetVariableAsync(Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(Task.FromResult((string)null));
+
             var target = GetTarget();
 
             // Act
@@ -2495,6 +2502,9 @@ namespace Take.Blip.Builder.UnitTests
                 To = "botidentity@msging.net",
                 From = "fromaccountagent@msging.net",
             };
+
+            // Mock the StateManager to return the expected state ID
+            StateManager.GetStateIdAsync(Arg.Any<IContext>(), Arg.Any<CancellationToken>()).Returns(stateId);
 
             Context.GetContextVariableAsync(httpBodyReponseVariableName, Arg.Any<CancellationToken>()).Returns(httpBodyReponseVariableValue);
 

--- a/src/Take.Blip.Client/Take.Blip.Client.csproj
+++ b/src/Take.Blip.Client/Take.Blip.Client.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lime.Messaging" Version="0.12.144" />
-    <PackageReference Include="Lime.Protocol" Version="0.12.144" />
-    <PackageReference Include="Lime.Transport.Tcp" Version="0.12.144" />
+    <PackageReference Include="Lime.Messaging" Version="0.12.160" />
+    <PackageReference Include="Lime.Protocol" Version="0.12.160" />
+    <PackageReference Include="Lime.Transport.Tcp" Version="0.12.160" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageReference Include="Serilog" Version="2.12.0" />


### PR DESCRIPTION
Adds new tests to `FlowManagerTests.cs` to handle exceptions in flows with invalid states, including mocks to simulate missing state variables and state manager behavior.

Updates the `Lime.Messaging`, `Lime.Protocol`, and `Lime.Transport.Tcp` dependencies in `Take.Blip.Client.csproj` from version `0.12.144` to `0.12.160`, ensuring improvements and bug fixes.