### PR TITLE
chore: Update Take.Blip.Client dependencies to version 0.7.544 AB#1025663

### DIFF
--- a/src/Samples/MediaReceiver/MediaReceiver.csproj
+++ b/src/Samples/MediaReceiver/MediaReceiver.csproj
@@ -7,8 +7,8 @@
   
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Take.Blip.Client" Version="0.5.135" />
-    <PackageReference Include="Take.Blip.Client.Console" Version="0.5.135" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.544" />
+    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.544" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Samples/MessageTypes/MessageTypes.csproj
+++ b/src/Samples/MessageTypes/MessageTypes.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Take.Blip.Client" Version="0.5.135" />
-    <PackageReference Include="Take.Blip.Client.Console" Version="0.5.135" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.544" />
+    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.544" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update the Take.Blip.Client and Take.Blip.Client.Console libraries in the MediaReceiver.csproj and MessageTypes.csproj solutions from version 0.5.135 to version 0.7.544.

This update was applied directly to the .csproj files within the <ItemGroup> element, replacing the old package versions with the newer ones. No other changes were made to the files.