### PR TITLE
chore: Updates Take.Blip.Client packages to version 0.7.544 AB#1025663 

### DIFF
--- a/src/Samples/FlashCards/bot-flash-cards-blip-sdk-csharp.csproj
+++ b/src/Samples/FlashCards/bot-flash-cards-blip-sdk-csharp.csproj
@@ -7,8 +7,8 @@
   
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Take.Blip.Client" Version="0.5.186" />
-    <PackageReference Include="Take.Blip.Client.Console" Version="0.5.186" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.544" />
+    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.544" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Templates/Take.Blip.Client.ConsoleTemplate/Take.Blip.Client.ConsoleTemplate.csproj
+++ b/src/Templates/Take.Blip.Client.ConsoleTemplate/Take.Blip.Client.ConsoleTemplate.csproj
@@ -7,8 +7,8 @@
   
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Take.Blip.Client" Version="0.7.537" />
-    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.537" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.544" />
+    <PackageReference Include="Take.Blip.Client.Console" Version="0.7.544" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Templates/Take.Blip.Client.WebTemplate/Take.Blip.Client.WebTemplate.csproj
+++ b/src/Templates/Take.Blip.Client.WebTemplate/Take.Blip.Client.WebTemplate.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>    
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />    
-    <PackageReference Include="Take.Blip.Client" Version="0.7.537" />
-    <PackageReference Include="Take.Blip.Client.Web" Version="0.7.537" />
+    <PackageReference Include="Take.Blip.Client" Version="0.7.544" />
+    <PackageReference Include="Take.Blip.Client.Web" Version="0.7.544" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Updates the dependencies for the Take.Blip.Client package and its subpackages (Take.Blip.Client.Console and Take.Blip.Client.Web) in the following project files:

bot-flash-cards-blip-sdk-csharp.csproj: from 0.5.186 to 0.7.544.
Take.Blip.Client.ConsoleTemplate.csproj: from 0.7.537 to 0.7.544.
Take.Blip.Client.WebTemplate.csproj: from 0.7.537 to 0.7.544.

These updates ensure the use of the latest versions, potentially fixing bugs, improving performance, or adding new features.