### PR TITLE
feat(logInput): Removed the required modifier AB#1033459

### DIFF
--- a/src/Take.Blip.Ai.Bot.Monitoring.Abstractions/Models/LogInput.cs
+++ b/src/Take.Blip.Ai.Bot.Monitoring.Abstractions/Models/LogInput.cs
@@ -2,11 +2,11 @@
 {
     public class LogInput
     {
-        public required string Title { get; set; }
-        public required string IdMessage { get; set; }
-        public required string From { get; set; }
+        public string Title { get; set; }
+        public string IdMessage { get; set; }
+        public string From { get; set; }
         public string? OriginalFrom { get; set; }
-        public required string To { get; set; }
+        public string To { get; set; }
         public string? OriginalTo { get; set; }
         public int? FlowVersion { get; set; }
         public string? Channel { get; set; }


### PR DESCRIPTION
Removed the required modifier from the Title, IdMessage, From, and To properties in the LogInput class.