### PR TITLE
feat: Corrigir atribuição de startStateId com operador seguro AB#1058941

### DIFF
--- a/src/Take.Blip.Builder/FlowManager.cs
+++ b/src/Take.Blip.Builder/FlowManager.cs
@@ -290,8 +290,7 @@ namespace Take.Blip.Builder
                                 ? titleToken?.ToString()
                                 : state?.Id;
                             var blockStopwatch = Stopwatch.StartNew();
-                            var startStateId = stateId;
-
+                            var startStateId = state?.Id;
                             var redirectToClientState = String.Empty;
                             try
                             {


### PR DESCRIPTION
Substitui a atribuição da variável `startStateId` para usar `state?.Id` em vez de `stateId`. Essa alteração garante que o valor seja derivado diretamente do estado atual (`state`) e previne possíveis problemas de referência nula.